### PR TITLE
Dockerfileに本番用のアセットプリコンパイルを追加とdatabase.ymlの修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,9 @@ RUN gem install bundler && bundle install
 
 COPY . .
 
+# 本番用のアセットプリコンパイル
+RUN RAILS_ENV=production bundle exec rails assets:precompile
+
 EXPOSE 3000
 
 CMD ["bash", "-c", "bundle exec rails server -b 0.0.0.0 -p 3000"]

--- a/config/database.yml
+++ b/config/database.yml
@@ -16,5 +16,4 @@ test:
   database: smart_shift_planner_test
 
 production:
-  <<: *default
-  database: smart_shift_planner_production
+  url: <%= ENV["DATABASE_URL"] %>


### PR DESCRIPTION
- Dockerfileに本番用のアセットプリコンパイルを追加
- database.ymlの修正
　Renderデプロイ時に「The `cable` database is not configured for the `production` environment. (ActiveRecord::AdapterNotSpecified)」でエラーあり。
```
production:
  <<: *default
  database: smart_shift_planner_production
```
上記を書きに修正
```
production:
  url: <%= ENV["DATABASE_URL"] %>
```