### PR TITLE
fix:Dockerfileのアセットプリコンパイル文を削除

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,6 @@ RUN gem install bundler && bundle install
 
 COPY . .
 
-# 本番用のアセットプリコンパイル
-RUN RAILS_ENV=production bundle exec rails assets:precompile
-
 EXPOSE 3000
 
 CMD ["bash", "-c", "bundle exec rails server -b 0.0.0.0 -p 3000"]


### PR DESCRIPTION
Renderでデプロイできず。アセットプリコンパイル文があることが原因と思われるため、削除。