### PR TITLE
fix:homeページのログアウトボタンの修正（デプロイエラー対応）

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -3,7 +3,9 @@
 
   <% if user_signed_in? %>
     <p>ログイン中：<%= current_user.name %> さん</p>
-    <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete } %>
+    <%= button_to "ログアウト", destroy_user_session_path, 
+                  method: :delete,
+                  class: "btn btn-outline-danger" %>
   <% else %>
     <%= link_to "新規登録", new_user_registration_path %>
     <%= link_to "ログイン", new_user_session_path %>


### PR DESCRIPTION
デプロイしたら、ログアウト時に500のインターナルエラー出現。
ログアウトボタンをlink_toからbutton_toへ変更してみる。