### PR TITLE
fix:Deviseの:remenberableを削除

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
 
   validates :name, presence: true
   # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable, :rememberable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :validatable
 end


### PR DESCRIPTION
デプロイで再度ログアウトで500エラーあり。
NoMethodError (undefined method remember_created_at=' for an instance of User)
User.rbのDevise機能:rememberableが影響している可能性あり、削除する。