### PR TITLE
フラッシュメッセージ、エラーメッセージを調整

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,9 +1,10 @@
 class User < ApplicationRecord
-  belongs_to :organization
+  belongs_to :organization, optional: true # resource.vaild?でorganization_nameでチェックが走るのでoptinal:trueでOK
 
   attr_accessor :organization_name
 
-  validates :name, presence: true
+  validates :name, presence: { message: "を入力してください"}
+  validates :organization_name, presence: { message: "を入力してください"} # フォーム用のエラーメッセージ
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable, :rememberable
   devise :database_authenticatable, :registerable,

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -24,7 +24,7 @@
       <div class="field mb-3">
         <%= f.label :password %>
         <% if @minimum_password_length %>
-        <em>(<%= @minimum_password_length %> characters minimum)</em>
+        <span class="text-muted">(<%= @minimum_password_length %>文字以上)</span>
         <% end %><br />
         <%= f.password_field :password, autocomplete: "new-password", class: "form-control" %>
       </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,26 +1,32 @@
-<h2>Log in</h2>
+<div class="container d-flex justify-content-center mt-5">
+  <div class="col-md-6">
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <h2 class="text-center mb-4">ログイン</h2>
+
+    <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+      <div class="field mb-3">
+        <%= f.label :Email %><br />
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control" %>
+      </div>
+
+      <div class="field mb-3">
+        <%= f.label :password %><br />
+        <%= f.password_field :password, autocomplete: "current-password", class: "form-control" %>
+      </div>
+
+      <%# if devise_mapping.rememberable? %>
+      <%#  <div class="field">
+          <%= f.check_box :remember_me %>
+      <%#    <%= f.label :remember_me %>
+      <%#  </div>
+      <% end %>
+
+      <div class="d-flex justify-content-between mb-3">
+        <%= link_to "戻る", root_path, class: "btn btn-secondary" %>
+        <%= f.submit "ログイン", class: "btn btn-primary" %>
+      </div>
+    <% end %>
+
+    <%#= render "devise/shared/links" %>
   </div>
-
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
-  </div>
-
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
-    </div>
-  <% end %>
-
-  <div class="actions">
-    <%= f.submit "Log in" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,12 +1,6 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation" data-turbo-cache="false">
-    <h2>
-      <%= I18n.t("errors.messages.not_saved",
-                 count: resource.errors.count,
-                 resource: resource.class.model_name.human.downcase)
-       %>
-    </h2>
-    <ul>
+  <div id="error_explanation" class="alert alert-danger">
+    <ul class="mb-0">
       <% resource.errors.full_messages.each do |message| %>
         <li><%= message %></li>
       <% end %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -2,12 +2,8 @@
   <%= link_to "Log in", new_session_path(resource_name) %><br />
 <% end %>
 
-<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
-<% end %>
-
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+  <%= link_to "パスワードをお忘れですか？", new_password_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,6 +39,21 @@
         </div>
       </div>
     </nav>
+
+    <div class="container mt-3">
+      <% flash.each do |key, message| %> <%# keyはフラッシュメッセージの種類（:notice / :alert / :error など）%>
+        <% bs_class =
+          case key.to_sym
+          when :notice then "alert-success"
+          when :alert then "alert-danger"
+          else "alert-info"
+          end %>
+        <div class="alert <%= bs_class %> alert-dismissible fade show text-center" role="alert">
+          <%= message %>
+        </div>
+      <% end %>
+    </div>
+
     <%= yield %>
   </body>
 </html>

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,7 @@ module Myapp
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    config.i18n.default_locale = :ja
+    config.i18n.available_locales = [:ja, :en]
   end
 end

--- a/config/locales/activerecord.ja.yml
+++ b/config/locales/activerecord.ja.yml
@@ -1,0 +1,24 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        name: "名前"
+        organization_name: "事業所名"
+        email: "メールアドレス"
+        password: "パスワード"
+        password_confirmation: "パスワード（確認用）"
+    errors:
+      models:
+        user:
+          attributes:
+            name:
+              blank: "を入力してください"
+            organization_name:
+              blank: "を入力してください"
+            email:
+              blank: "を入力してください"
+              taken: "はすでに使用されています"
+            password:
+              blank: "を入力してください"
+            password_confirmation:
+              confirmation: "がパスワードと一致していません"

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,7 @@
+ja:
+  devise:
+    registrations:
+      signed_up: "新規登録が完了しました"
+    sessions:
+      signed_in: "ログインしました"
+      signed_out: "ログアウトしました"


### PR DESCRIPTION
## 新規登録、ログイン時

以下の表示を調整
- 遷移先でフラッシュメッセージ「新規登録しました」「ログインしました」の表示
- 入力欄が空欄の場所に、エラー部分の表示
- メールアドレスが重複していると、重複のエラー表示
- メールアドレス（確認用）が違うと、エラーでお知らせ
