### PR TITLE
add:職員新規登録画面とoccupation/staffモデル作成

### DIFF
--- a/app/controllers/staffs_controller.rb
+++ b/app/controllers/staffs_controller.rb
@@ -1,0 +1,36 @@
+class StaffsController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    @staffs = current_user.staffs.includes(:occupation).order(:last_name_kana, :first_name_kana) # orderはカナ順の表示
+  end
+
+  def new
+    @staff = current_user.staffs.build # 入力フォームの受け皿作成
+    @occupations = Occupation.all
+  end
+
+  def create
+    @staff = current_user.staffs.build(staff_params) # フォームから送られてきた情報を@staffに入れる
+    @occupations = Occupation.all
+
+    if @staff.save
+      redirect_to staffs_path, notice: "職員を登録しました。"
+    else
+      flash.now[:alert] = "登録に失敗しました。入力内容を確認してください。"
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def staff_params
+    params.require(:staff).permit(
+      :occupation_id,
+      :last_name, :first_name,
+      :last_name_kana, :first_name_kana,
+      :can_day, :can_early, :can_late, :can_night,
+      :can_visit, :can_drive, :can_cook
+    )
+  end
+end

--- a/app/helpers/staffs_helper.rb
+++ b/app/helpers/staffs_helper.rb
@@ -1,0 +1,2 @@
+module StaffsHelper
+end

--- a/app/models/occupation.rb
+++ b/app/models/occupation.rb
@@ -1,0 +1,5 @@
+class Occupation < ApplicationRecord
+  has_many :staffs, dependent: :nullify # 職種削除時はstaffのoccupation_idをNULLにする
+
+  validates :name, presence: true, uniqueness: { case_sensitive: false } # case_sensitive: falseは大文字小文字を区別しない意味
+end

--- a/app/models/staff.rb
+++ b/app/models/staff.rb
@@ -1,0 +1,9 @@
+class Staff < ApplicationRecord
+  belongs_to :occupation
+  belongs_to :user
+
+  validates :last_name,     presence: true
+  validates :first_name,    presence: true
+  validates :last_name_kana,  presence: true
+  validates :first_name_kana, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   belongs_to :organization, optional: true # resource.vaild?でorganization_nameでチェックが走るのでoptinal:trueでOK
+  has_many :staffs, dependent: :destroy
 
   attr_accessor :organization_name
 

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -9,7 +9,7 @@
 
     <div class="d-flex flex-column gap-2 mb-5 align-items-start">
       <%= link_to "職員一覧", "#", class: "btn btn-outline-secondary btn-sm text-start px-3 d-inline-block", style: "background-color:#ffffff; border:1px solid #97cdf3; color:#333; width:auto;" %>
-      <%= link_to "職員新規登録", "#",  class: "btn btn-outline-secondary btn-sm text-start px-3 d-inline-block", style: "background-color:#ffffff; border:1px solid #97cdf3; color:#333;" %>
+      <%= link_to "職員新規登録", new_staff_path,  class: "btn btn-outline-secondary btn-sm text-start px-3 d-inline-block", style: "background-color:#ffffff; border:1px solid #97cdf3; color:#333;" %>
     </div>
   </div>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,7 +26,9 @@
   <body>
     <nav class="navbar navbar-expand-lg mb-4" style="background-color: #97cdf3; border-bottom: 8px solid #e6f0f0;">
       <div class="container d-flex justify-content-between">
-        <%= link_to "Smart Shift Planner", root_path, class: "navbar-brand text-white fw-bold" %>
+        <%= link_to "Smart Shift Planner",
+                    (user_signed_in? ? dashboard_path : root_path),
+                    class: "navbar-brand text-white fw-bold" %>
 
         <div class="d-flex align-items-center">
           <% if user_signed_in? %>

--- a/app/views/staffs/index.html.erb
+++ b/app/views/staffs/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Staffs#index</h1>
+<p>Find me in app/views/staffs/index.html.erb</p>

--- a/app/views/staffs/new.html.erb
+++ b/app/views/staffs/new.html.erb
@@ -1,0 +1,162 @@
+<div class="container-fluid">
+  <div class="row min-vh-100">
+    <div class="col-md-3 col-lg-2 p-0">
+      <%= render "layouts/sidebar" %>
+    </div>
+
+    <div class="col-md-9 col-lg-10">
+      <div class="container py-4">
+        <div class="row">
+          <div class="col-lg-8 mx-auto">
+
+            <div class="d-flex align-items-center mb-5">
+              <h1 class="h4 fw-bold mb-0 me-3">職員新規登録</h1>
+              <%= link_to "職員一覧へ移動", staffs_path, class: "btn btn-secondary btn-sm py-1 px-2" %>
+            </div>
+
+            <% if @staff.errors.any? %>
+              <div class="alert alert-danger">
+                <ul class="mb-0">
+                  <% @staff.errors.full_messages.each do |msg| %>
+                    <li><%= msg %></li>
+                  <% end %>
+                </ul>
+              </div>
+            <% end %>
+
+            <%= form_with model: @staff, local: true do |f| %>
+              <div class="row mb-3">
+                <label class="col-md-2 col-form-label fw-bold">名前</label>
+                <div class="col-md-3 mb-2 mb-md-0">
+                  <div class="input-group">
+                    <span class="input-group-text">姓</span>
+                    <%= f.text_field :last_name, class: "form-control" %>
+                  </div>
+                </div>
+                <div class="col-md-3">
+                  <div class="input-group">
+                    <span class="input-group-text">名</span>
+                    <%= f.text_field :first_name, class: "form-control" %>
+                  </div>
+                </div>
+              </div>
+
+              <div class="row mb-3">
+                <label class="col-md-2 col-form-label fw-bold">なまえ</label>
+                <div class="col-md-3 mb-2 mb-md-0">
+                  <div class="input-group">
+                    <span class="input-group-text">せい</span>
+                    <%= f.text_field :last_name_kana, class: "form-control" %>
+                  </div>
+                </div>
+                <div class="col-md-3">
+                  <div class="input-group">
+                    <span class="input-group-text">めい</span>
+                    <%= f.text_field :first_name_kana, class: "form-control" %>
+                  </div>
+                </div>
+              </div>
+
+              <div class="row mb-4">
+                <label class="col-md-2 col-form-label fw-bold">職種</label>
+                <div class="col-md-3">
+                  <%= f.collection_select :occupation_id,
+                                          @occupations,
+                                          :id,
+                                          :name,
+                                          { prompt: "選択してください" },
+                                          { class: "form-select" } %>
+                </div>
+              </div>
+
+              <div class="row mb-4">
+                <label class="col-md-2 col-form-label fw-bold">勤務可否</label>
+                <div class="col-md-10">
+                  <div class="row mb-2 align-items-center">
+                    <div class="col-3 col-md-2">日勤</div>
+                    <div class="col-9 col-md-10">
+                      <div class="form-check form-check-inline">
+                        <%= f.radio_button :can_day, true, id: "staff_can_day_true", class: "form-check-input" %>
+                        <label class="form-check-label" for="staff_can_day_true">可</label>
+                      </div>
+                      <div class="form-check form-check-inline">
+                        <%= f.radio_button :can_day, false, id: "staff_can_day_false", class: "form-check-input" %>
+                        <label class="form-check-label" for="staff_can_day_false">不可</label>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="row mb-2 align-items-center">
+                    <div class="col-3 col-md-2">早番</div>
+                    <div class="col-9 col-md-10">
+                      <div class="form-check form-check-inline">
+                        <%= f.radio_button :can_early, true, id: "staff_can_early_true", class: "form-check-input" %>
+                        <label class="form-check-label" for="staff_can_early_true">可</label>
+                      </div>
+                      <div class="form-check form-check-inline">
+                        <%= f.radio_button :can_early, false, id: "staff_can_early_false", class: "form-check-input" %>
+                        <label class="form-check-label" for="staff_can_early_false">不可</label>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="row mb-2 align-items-center">
+                    <div class="col-3 col-md-2">遅番</div>
+                    <div class="col-9 col-md-10">
+                      <div class="form-check form-check-inline">
+                        <%= f.radio_button :can_late, true, id: "staff_can_late_true", class: "form-check-input" %>
+                        <label class="form-check-label" for="staff_can_late_true">可</label>
+                      </div>
+                      <div class="form-check form-check-inline">
+                        <%= f.radio_button :can_late, false, id: "staff_can_late_false", class: "form-check-input" %>
+                        <label class="form-check-label" for="staff_can_late_false">不可</label>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="row mb-2 align-items-center">
+                    <div class="col-3 col-md-2">夜勤</div>
+                    <div class="col-9 col-md-10">
+                      <div class="form-check form-check-inline">
+                        <%= f.radio_button :can_night, true, id: "staff_can_night_true", class: "form-check-input" %>
+                        <label class="form-check-label" for="staff_can_night_true">可</label>
+                      </div>
+                      <div class="form-check form-check-inline">
+                        <%= f.radio_button :can_night, false, id: "staff_can_night_false", class: "form-check-input" %>
+                        <label class="form-check-label" for="staff_can_night_false">不可</label>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div class="row mb-4">
+                <label class="col-md-2 col-form-label fw-bold">スキル</label>
+                <div class="col-md-10">
+                  <div class="form-check form-check-inline">
+                    <%= f.check_box :can_visit, class: "form-check-input", id: "staff_can_visit" %>
+                    <label class="form-check-label" for="staff_can_visit">訪問</label>
+                  </div>
+                  <div class="form-check form-check-inline">
+                    <%= f.check_box :can_drive, class: "form-check-input", id: "staff_can_drive" %>
+                    <label class="form-check-label" for="staff_can_drive">運転</label>
+                  </div>
+                  <div class="form-check form-check-inline">
+                    <%= f.check_box :can_cook, class: "form-check-input", id: "staff_can_cook" %>
+                    <label class="form-check-label" for="staff_can_cook">調理</label>
+                  </div>
+                </div>
+              </div>
+
+              <div class="row mt-4">
+                <div class="col-md-8 text-end">
+                  <%= f.submit "登録", class: "btn btn-primary px-4" %>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,11 @@
 Rails.application.routes.draw do
+  get "staffs/index"
+  get "staffs/new"
   get "dashboards/index"
   devise_for :users, controllers: {
     registrations: 'users/registrations'
   }
   root to: 'pages#home'
   get 'dashboard', to: 'dashboards#index'
+  resources :staffs, only: [:index, :new, :create]
 end

--- a/db/migrate/20251210064508_create_occupations.rb
+++ b/db/migrate/20251210064508_create_occupations.rb
@@ -1,0 +1,9 @@
+class CreateOccupations < ActiveRecord::Migration[8.1]
+  def change
+    create_table :occupations do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20251210065802_create_staffs.rb
+++ b/db/migrate/20251210065802_create_staffs.rb
@@ -1,0 +1,24 @@
+class CreateStaffs < ActiveRecord::Migration[8.1]
+  def change
+    create_table :staffs do |t|
+      t.references :occupation, null: false, foreign_key: true
+      t.references :user,       null: false, foreign_key: true
+
+      t.string :last_name,      null: false
+      t.string :first_name,     null: false
+      t.string :last_name_kana, null: false
+      t.string :first_name_kana, null: false
+
+      t.boolean :can_day,   null: false, default: false
+      t.boolean :can_early, null: false, default: false
+      t.boolean :can_late,  null: false, default: false
+      t.boolean :can_night, null: false, default: false
+
+      t.boolean :can_visit, null: false, default: false
+      t.boolean :can_drive, null: false, default: false
+      t.boolean :can_cook,  null: false, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,41 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_12_09_045006) do
+ActiveRecord::Schema[8.1].define(version: 2025_12_10_065802) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "occupations", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "organizations", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "name", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_organizations_on_name", unique: true
+  end
+
+  create_table "staffs", force: :cascade do |t|
+    t.boolean "can_cook", default: false, null: false
+    t.boolean "can_day", default: false, null: false
+    t.boolean "can_drive", default: false, null: false
+    t.boolean "can_early", default: false, null: false
+    t.boolean "can_late", default: false, null: false
+    t.boolean "can_night", default: false, null: false
+    t.boolean "can_visit", default: false, null: false
+    t.datetime "created_at", null: false
+    t.string "first_name", null: false
+    t.string "first_name_kana", null: false
+    t.string "last_name", null: false
+    t.string "last_name_kana", null: false
+    t.bigint "occupation_id", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["occupation_id"], name: "index_staffs_on_occupation_id"
+    t.index ["user_id"], name: "index_staffs_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -36,5 +62,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_09_045006) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "staffs", "occupations"
+  add_foreign_key "staffs", "users"
   add_foreign_key "users", "organizations"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,12 @@
-# This file should ensure the existence of records required to run the application in every environment (production,
-# development, test). The code here should be idempotent so that it can be executed at any point in every environment.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+occupations = [
+  "管理者",
+  "看護師",
+  "介護福祉士",
+  "ケアマネージャー",
+  "管理栄養士",
+  "事務"
+]
+
+occupations.each do |name|
+  Occupation.find_or_create_by!(name: name)
+end

--- a/test/controllers/staffs_controller_test.rb
+++ b/test/controllers/staffs_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class StaffsControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get staffs_index_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get staffs_new_url
+    assert_response :success
+  end
+end

--- a/test/fixtures/occupations.yml
+++ b/test/fixtures/occupations.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/test/fixtures/staffs.yml
+++ b/test/fixtures/staffs.yml
@@ -1,0 +1,31 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  occupation: one
+  user: one
+  last_name: MyString
+  first_name: MyString
+  last_name_kana: MyString
+  first_name_kana: MyString
+  can_day: false
+  can_early: false
+  can_late: false
+  can_night: false
+  can_visit: false
+  can_drive: false
+  can_cook: false
+
+two:
+  occupation: two
+  user: two
+  last_name: MyString
+  first_name: MyString
+  last_name_kana: MyString
+  first_name_kana: MyString
+  can_day: false
+  can_early: false
+  can_late: false
+  can_night: false
+  can_visit: false
+  can_drive: false
+  can_cook: false

--- a/test/models/occupation_test.rb
+++ b/test/models/occupation_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class OccupationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/staff_test.rb
+++ b/test/models/staff_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class StaffTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
以下を追加
・occupationテーブル作成とseedで職種登録
・staffテーブル作成
・職員新規登録画面を作成
・ヘッダーのロゴクリックをログインと未ログインでの、画面遷移先を調整

新規登録できていることをコンソールで確認済