### PR TITLE
fix:render用にyml修正

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -18,13 +18,13 @@ default: &default
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  host: db
-  username: postgres
-  password: password
 
 development:
   <<: *default
+  host: db
   database: myapp_development
+  username: postgres
+  password: password
 
   # The specified database role being used to connect to PostgreSQL.
   # To create additional roles in PostgreSQL see `$ createuser --help`.
@@ -58,7 +58,10 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
+  host: db
   database: myapp_test
+  username: postgres
+  password: password
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -87,20 +90,24 @@ test:
 # for a full overview on how database connection configuration can be specified.
 #
 production:
-  primary: &primary_production
-    <<: *default
-    database: myapp_production
-    username: myapp
-    password: <%= ENV["MYAPP_DATABASE_PASSWORD"] %>
-  cache:
-    <<: *primary_production
-    database: myapp_production_cache
-    migrations_paths: db/cache_migrate
-  queue:
-    <<: *primary_production
-    database: myapp_production_queue
-    migrations_paths: db/queue_migrate
-  cable:
-    <<: *primary_production
-    database: myapp_production_cable
-    migrations_paths: db/cable_migrate
+  <<: *default
+  url: <%= ENV.fetch("DATABASE_URL") %>
+
+# 将来マルチDBにしたくなったときのテンプレ
+  # primary: &primary_production
+  #   <<: *default
+  #   database: myapp_production
+  #   username: myapp
+  #   password: <%= ENV["MYAPP_DATABASE_PASSWORD"] %>
+  # cache:
+  #   <<: *primary_production
+  #   database: myapp_production_cache
+  #   migrations_paths: db/cache_migrate
+  # queue:
+  #   <<: *primary_production
+  #   database: myapp_production_queue
+  #   migrations_paths: db/queue_migrate
+  # cable:
+  #   <<: *primary_production
+  #   database: myapp_production_cable
+  #   migrations_paths: db/cable_migrate


### PR DESCRIPTION
新しく作成したoccupation/staffテーブルがrender上でmigrateできないため、databese.ymlを修正。