### PR TITLE
add:職員編集画面を作成

### DIFF
--- a/app/controllers/staffs_controller.rb
+++ b/app/controllers/staffs_controller.rb
@@ -1,5 +1,7 @@
 class StaffsController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_staff, only: [:edit, :update, :destroy]
+  before_action :set_occupations, only: [:new, :create, :edit, :update]
 
   def index
     @staffs = current_user.staffs.includes(:occupation).order(:last_name_kana, :first_name_kana) # orderはカナ順の表示
@@ -7,12 +9,10 @@ class StaffsController < ApplicationController
 
   def new
     @staff = current_user.staffs.build # 入力フォームの受け皿作成
-    @occupations = Occupation.all
   end
 
   def create
     @staff = current_user.staffs.build(staff_params) # フォームから送られてきた情報を@staffに入れる
-    @occupations = Occupation.all
 
     if @staff.save
       redirect_to staffs_path, notice: "職員を登録しました。"
@@ -22,7 +22,32 @@ class StaffsController < ApplicationController
     end
   end
 
+  def edit
+  end
+
+  def update
+    if @staff.update(staff_params)
+      redirect_to staffs_path, notice: "職員情報を更新しました"
+    else
+      flash.now[:alert] = "更新に失敗しました。入力内容を確認してください。"
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @staff.destroy
+    redirect_to staffs_path, notice: "削除しました"
+  end
+
   private
+
+  def set_staff
+    @staff = current_user.staffs.find(params[:id])
+  end
+
+  def set_occupations
+    @occupations = Occupation.all
+  end
 
   def staff_params
     params.require(:staff).permit(

--- a/app/views/staffs/edit.html.erb
+++ b/app/views/staffs/edit.html.erb
@@ -1,0 +1,162 @@
+<div class="container-fluid">
+  <div class="row min-vh-100">
+    <div class="col-md-3 col-lg-2 p-0">
+      <%= render "layouts/sidebar" %>
+    </div>
+
+    <div class="col-md-9 col-lg-10">
+      <div class="container py-4">
+        <div class="row">
+          <div class="col-lg-8 mx-auto">
+
+            <div class="d-flex align-items-center mb-5">
+              <h1 class="h4 fw-bold mb-0 me-3">職員情報編集</h1>
+              <%= link_to "職員一覧へ戻る", staffs_path, class: "btn btn-secondary btn-sm py-1 px-2" %>
+            </div>
+
+            <% if @staff.errors.any? %>
+              <div class="alert alert-danger">
+                <ul class="mb-0">
+                  <% @staff.errors.full_messages.each do |msg| %>
+                    <li><%= msg %></li>
+                  <% end %>
+                </ul>
+              </div>
+            <% end %>
+
+            <%= form_with model: @staff, local: true do |f| %>
+              <div class="row mb-3">
+                <label class="col-md-2 col-form-label fw-bold">名前</label>
+                <div class="col-md-3 mb-2 mb-md-0">
+                  <div class="input-group">
+                    <span class="input-group-text">姓</span>
+                    <%= f.text_field :last_name, class: "form-control" %>
+                  </div>
+                </div>
+                <div class="col-md-3">
+                  <div class="input-group">
+                    <span class="input-group-text">名</span>
+                    <%= f.text_field :first_name, class: "form-control" %>
+                  </div>
+                </div>
+              </div>
+
+              <div class="row mb-3">
+                <label class="col-md-2 col-form-label fw-bold">なまえ</label>
+                <div class="col-md-3 mb-2 mb-md-0">
+                  <div class="input-group">
+                    <span class="input-group-text">せい</span>
+                    <%= f.text_field :last_name_kana, class: "form-control" %>
+                  </div>
+                </div>
+                <div class="col-md-3">
+                  <div class="input-group">
+                    <span class="input-group-text">めい</span>
+                    <%= f.text_field :first_name_kana, class: "form-control" %>
+                  </div>
+                </div>
+              </div>
+
+              <div class="row mb-4">
+                <label class="col-md-2 col-form-label fw-bold">職種</label>
+                <div class="col-md-3">
+                  <%= f.collection_select :occupation_id,
+                                          @occupations,
+                                          :id,
+                                          :name,
+                                          { prompt: "選択してください" },
+                                          { class: "form-select" } %>
+                </div>
+              </div>
+
+              <div class="row mb-4">
+                <label class="col-md-2 col-form-label fw-bold">勤務可否</label>
+                <div class="col-md-10">
+                  <div class="row mb-2 align-items-center">
+                    <div class="col-3 col-md-2">日勤</div>
+                    <div class="col-9 col-md-10">
+                      <div class="form-check form-check-inline">
+                        <%= f.radio_button :can_day, true, id: "staff_can_day_true", class: "form-check-input" %>
+                        <label class="form-check-label" for="staff_can_day_true">可</label>
+                      </div>
+                      <div class="form-check form-check-inline">
+                        <%= f.radio_button :can_day, false, id: "staff_can_day_false", class: "form-check-input" %>
+                        <label class="form-check-label" for="staff_can_day_false">不可</label>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="row mb-2 align-items-center">
+                    <div class="col-3 col-md-2">早番</div>
+                    <div class="col-9 col-md-10">
+                      <div class="form-check form-check-inline">
+                        <%= f.radio_button :can_early, true, id: "staff_can_early_true", class: "form-check-input" %>
+                        <label class="form-check-label" for="staff_can_early_true">可</label>
+                      </div>
+                      <div class="form-check form-check-inline">
+                        <%= f.radio_button :can_early, false, id: "staff_can_early_false", class: "form-check-input" %>
+                        <label class="form-check-label" for="staff_can_early_false">不可</label>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="row mb-2 align-items-center">
+                    <div class="col-3 col-md-2">遅番</div>
+                    <div class="col-9 col-md-10">
+                      <div class="form-check form-check-inline">
+                        <%= f.radio_button :can_late, true, id: "staff_can_late_true", class: "form-check-input" %>
+                        <label class="form-check-label" for="staff_can_late_true">可</label>
+                      </div>
+                      <div class="form-check form-check-inline">
+                        <%= f.radio_button :can_late, false, id: "staff_can_late_false", class: "form-check-input" %>
+                        <label class="form-check-label" for="staff_can_late_false">不可</label>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="row mb-2 align-items-center">
+                    <div class="col-3 col-md-2">夜勤</div>
+                    <div class="col-9 col-md-10">
+                      <div class="form-check form-check-inline">
+                        <%= f.radio_button :can_night, true, id: "staff_can_night_true", class: "form-check-input" %>
+                        <label class="form-check-label" for="staff_can_night_true">可</label>
+                      </div>
+                      <div class="form-check form-check-inline">
+                        <%= f.radio_button :can_night, false, id: "staff_can_night_false", class: "form-check-input" %>
+                        <label class="form-check-label" for="staff_can_night_false">不可</label>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div class="row mb-4">
+                <label class="col-md-2 col-form-label fw-bold">スキル</label>
+                <div class="col-md-10">
+                  <div class="form-check form-check-inline">
+                    <%= f.check_box :can_visit, class: "form-check-input", id: "staff_can_visit" %>
+                    <label class="form-check-label" for="staff_can_visit">訪問</label>
+                  </div>
+                  <div class="form-check form-check-inline">
+                    <%= f.check_box :can_drive, class: "form-check-input", id: "staff_can_drive" %>
+                    <label class="form-check-label" for="staff_can_drive">運転</label>
+                  </div>
+                  <div class="form-check form-check-inline">
+                    <%= f.check_box :can_cook, class: "form-check-input", id: "staff_can_cook" %>
+                    <label class="form-check-label" for="staff_can_cook">調理</label>
+                  </div>
+                </div>
+              </div>
+
+              <div class="row mt-4">
+                <div class="col-md-8 d-flex justify-conten-end gap-2">
+                  <%= f.submit "更新", class: "btn btn-primary px-4" %>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/staffs/index.html.erb
+++ b/app/views/staffs/index.html.erb
@@ -15,7 +15,7 @@
         <table class="table table-sm table-bordered align-middle">
             <thead>
               <tr class="text-center">
-                <th style="width: 80px; background-color: #e6f0f0;">編集</th>
+                <th style="width: 140px; background-color: #e6f0f0;">操作</th>
                 <th style="background-color: #e6f0f0;">スタッフ名</th>
                 <th style="background-color: #e6f0f0;">職種</th>
                 <th style="background-color: #e6f0f0;">早番</th>
@@ -31,8 +31,21 @@
             <% if @staffs.any? %>
                 <% @staffs.each do |staff| %>
                 <tr>
-                  <td>
-                    <%= link_to "編集", "#" %>
+                  <td class= "text-center">
+                    <div class="d-inline-flex align-items-center gap-1">                    
+                      <%= button_to "編集", 
+                                  edit_staff_path(staff),
+                                  method: :get,
+                                  class: "btn btn-outline-secondary btn-sm px-2 py-0",
+                                  form_class: "d-inline m-0" %>
+
+                      <%= button_to "削除",
+                                    staff_path(staff),
+                                    method: :delete,
+                                    form: { data: { turbo_confirm: "この職員を削除します。よろしいですか？" } },
+                                    class: "btn btn-outline-danger btn-sm px-2 py-0",
+                                    form_class: "d-inline m-0" %>
+                    </div>
                   </td>
 
                   <td><%= "#{staff.last_name} #{staff.first_name}" %></td>

--- a/config/locales/activerecord.ja.yml
+++ b/config/locales/activerecord.ja.yml
@@ -26,6 +26,7 @@ ja:
               taken: "はすでに使用されています"
             password:
               blank: "を入力してください"
+              too_short: "は%{count}文字以上で入力してください"
             password_confirmation:
               confirmation: "がパスワードと一致していません"
         staff:

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -6,10 +6,11 @@ ja:
       signed_in: "ログインしました"
       signed_out: "ログアウトしました"
     failure:
-      invalid: "メールアドレスまたはパスワードが正しくありません。"
-      not_found_in_database: "メールアドレスまたはパスワードが正しくありません。"
-      unauthenticated: "ログインしてください。"
+      invalid: "メールアドレスまたはパスワードが正しくありません"
+      not_found_in_database: "メールアドレスまたはパスワードが正しくありません"
+      unauthenticated: "ログインしてください"
       user:
-        invalid: "メールアドレスまたはパスワードが正しくありません。"
-        not_found_in_database: "メールアドレスまたはパスワードが正しくありません。"
-        unauthenticated: "ログインしてください。"
+        invalid: "メールアドレスまたはパスワードが正しくありません"
+        not_found_in_database: "メールアドレスまたはパスワードが正しくありません"
+        unauthenticated: "ログインしてください"
+        already_authenticated: "すでにログインしています"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,9 @@
 Rails.application.routes.draw do
-  get "staffs/index"
-  get "staffs/new"
   get "dashboards/index"
   devise_for :users, controllers: {
     registrations: 'users/registrations'
   }
   root to: 'pages#home'
   get 'dashboard', to: 'dashboards#index'
-  resources :staffs, only: [:index, :new, :create]
+  resources :staffs, only: [:index, :new, :create, :edit, :update, :destroy]
 end


### PR DESCRIPTION
職員編集画面を実装
・職員一覧画面に編集/削除ボタンを追加し、 操作できるようにした。
・職員情報編集画面で情報を編集できるようにしました。
・ローカル上では動作問題ないこと確認済