### PR TITLE
fix:シフト作成の年月入力で範囲外の入力時の挙動整備

### DIFF
--- a/app/models/shift_month.rb
+++ b/app/models/shift_month.rb
@@ -5,6 +5,10 @@ class ShiftMonth < ApplicationRecord
   has_many :shift_day_settings, dependent: :destroy
   has_many :shift_day_assignments, dependent: :destroy
 
+  validates :year, presence: true
+  validates :month, presence: true
+  validates :month, inclusion: { in: 1..12 }
+
   SHIFT_KINDS = %i[day early late night].freeze
 
   # 日別の勤務ON/OFFを返す（MVP:設定がなければ全部ON）

--- a/app/views/shift_months/new.html.erb
+++ b/app/views/shift_months/new.html.erb
@@ -5,7 +5,7 @@
     </div>
 
     <div class="col-md-9 col-lg-10 py-4">
-      <div class="container">
+      <div class="container px-5">
         <h1 class="h4 fw-bold mb-4">シフト作成（月を選択）</h1>
 
         <% if @shift_month.errors.any? %>
@@ -31,7 +31,7 @@
             </div>
 
             <div class="col-auto">
-              <%= f.submit "新規作成", class: "btn btn-primary" %>
+              <%= f.submit "作成する", class: "btn btn-primary" %>
             </div>
           </div>
         <% end %>

--- a/config/locales/activerecord.ja.yml
+++ b/config/locales/activerecord.ja.yml
@@ -13,6 +13,9 @@ ja:
         first_name: "名"
         last_name_kana: "姓（せい）"
         first_name_kana: "名（めい）"
+      shift_month:
+        year: "年"
+        month: "月"
     errors:
       models:
         user:


### PR DESCRIPTION
以下を調整しました。
・シフト作成の年月を空欄にしたり、1〜12以外の月を入力したい際のエラー
→アラート表示へ
・シフト設定画面で日曜始まりを、月曜始まりに変更