### PR TITLE
add:有休・希望休の振り分けを実装

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -170,11 +170,26 @@
   border-left: none;
 }
 
-.slot-day .holiday-in-slot {
-  font-size: 10px;
+.holiday-in-slot {
   line-height: 1.2;
   color: #dc3545;
   white-space: nowrap;
+  display: inline-block;
+  padding: 0 2px;
+  border-radius: 2px;
+}
+
+.holiday-in-slot.holiday-admin-off {
+  background-color: #dbdbdb;
+}
+
+.holiday-in-slot.holiday-requested-off,
+.holiday-in-slot:not(.holiday-admin-off):not(.holiday-paid-leave) {
+  background-color: #facadb;
+}
+
+.holiday-in-slot.holiday-paid-leave {
+  background-color: #d3f8d3;
 }
 
 .occ-row-req .req-count {

--- a/app/controllers/shift_months_controller.rb
+++ b/app/controllers/shift_months_controller.rb
@@ -307,9 +307,13 @@ class ShiftMonthsController < ApplicationController
 
     conflicts.delete_all
 
-    @shift_month.staff_holiday_requests.find_or_create_by!(staff: staff, date: date)
+    holiday_type = params[:holiday_type].presence || "admin_off"
 
-    redirect_to settings_shift_month_path(@shift_month, tab: "holiday", staff_id: staff.id), notice: "休日希望を追加しました"
+    request = @shift_month.staff_holiday_requests.find_or_initialize_by(staff: staff, date: date)
+    request.holiday_type = holiday_type
+    request.save!
+
+    redirect_to settings_shift_month_path(@shift_month, tab: "holiday", staff_id: staff.id), notice: "休日設定を追加しました"
   rescue ArgumentError
     redirect_to settings_shift_month_path(@shift_month, tab: "holiday", staff_id: params[:staff_id]), alert: "日付の形式が正しくありません"
   end
@@ -319,7 +323,7 @@ class ShiftMonthsController < ApplicationController
     staff_id = request.staff_id
     request.destroy!
 
-    redirect_to settings_shift_month_path(@shift_month, tab: "holiday", staff_id: staff_id), notice: "休日希望を削除しました"
+    redirect_to settings_shift_month_path(@shift_month, tab: "holiday", staff_id: staff_id), notice: "休日設定を削除しました"
   end
 
   def update_weekday_requirements
@@ -446,6 +450,7 @@ class ShiftMonthsController < ApplicationController
 
     date  = Date.iso8601(params.require(:date))
     kind_str = params.require(:kind).to_s
+    holiday_type = params[:holiday_type].presence
     staff_id = params.require(:staff_id).to_i
     ui_wday  = ShiftMonth.ui_wday(date)
 
@@ -493,7 +498,18 @@ class ShiftMonthsController < ApplicationController
 
         next_day = date + 1
         scope.where(date: next_day, staff_id: staff_id, shift_kind: %i[day early late]).delete_all
+
       elsif kind_str == "off"
+        holiday_type_for_save =
+          if %w[requested_off paid_leave].include?(holiday_type)
+            holiday_type
+          else
+            nil
+          end
+
+        # まず、その職員の当日勤務を全部外す
+        scope.where(date: date, staff_id: staff_id, shift_kind: %i[day early late night]).delete_all
+
         # 「夜勤なし」はstaff_idは0で来るため、当日nightに入っている職員をDBから拾う
         night_row = scope.find_by(date: date, shift_kind: :night)
         night_staff_id = night_row&.staff_id
@@ -539,6 +555,26 @@ class ShiftMonthsController < ApplicationController
               draft_token: token,
               staff_day_time_option_id: day_opt_id
             )
+          end
+        end
+
+        target_staff_id = night_staff_id.presence || staff_id
+
+        if target_staff_id.present? && target_staff_id.to_i > 0
+          existing_request = @shift_month.staff_holiday_requests.find_by(
+            staff_id: target_staff_id,
+            date: date
+          )
+
+          if holiday_type_for_save.present?
+            request = existing_request || @shift_month.staff_holiday_requests.new(
+              staff_id: target_staff_id,
+              date: date
+            )
+            request.holiday_type = holiday_type_for_save
+            request.save!
+          else
+            existing_request&.destroy
           end
         end
       else

--- a/app/javascript/controllers/shift_edit_controller.js
+++ b/app/javascript/controllers/shift_edit_controller.js
@@ -15,16 +15,22 @@ export default class extends Controller {
     if (!display) return
 
     const nameBase = select.dataset.staffName || ""
-    const raw = select.value // "early" / "late" / "off" / "day:12"
-    const isOff = (raw === "off")
+    const raw = select.value // "early" / "late" / "off" / "off:requested_off" / "off:paid_leave" / "day:12"
 
     let kind = raw
+    let holidayType = null
     let staffDayTimeOptionId = null
     if (raw && raw.startsWith("day:")) {
       kind = "day"
       const parts = raw.split(":")
       staffDayTimeOptionId = parts[1] ? parseInt(parts[1], 10) : null
+    } else if (raw && raw.startsWith("off:")) {
+      kind = "off"
+      const parts = raw.split(":")
+      holidayType = parts[1] || null
     }
+
+    const isOff = (kind === "off")
 
     // 表示用の時間文字列（optionのdata-time-textを優先）
     let timeText = ""
@@ -43,7 +49,29 @@ export default class extends Controller {
       nameEl.className = "shift-edit-name"
       display.appendChild(nameEl)
     }
-    nameEl.textContent = `${nameBase}${isOff ? "(休)" : ""}`
+    let offLabel = ""
+    if (isOff) {
+      if (holidayType === "requested_off") offLabel = "(希望休)"
+      else if (holidayType === "paid_leave") offLabel = "(有休)"
+      else offLabel = "(休)"
+    }
+
+    nameEl.classList.remove(
+      "holiday-in-slot",
+      "holiday-admin-off",
+      "holiday-requested-off",
+      "holiday-paid-leave"
+    )
+
+    if (isOff) {
+      if (holidayType === "requested_off") {
+        nameEl.classList.add("holiday-in-slot", "holiday-requested-off")
+      } else if (holidayType === "paid_leave") {
+        nameEl.classList.add("holiday-in-slot", "holiday-paid-leave")
+      }
+    }
+
+    nameEl.textContent = `${nameBase}${offLabel}`
 
     let timeEl = display.querySelector(".shift-edit-time")
     if (timeText) {
@@ -57,7 +85,7 @@ export default class extends Controller {
       if (timeEl) timeEl.remove()
     }
 
-    this.queueSave(select, { kind, staffDayTimeOptionId })
+    this.queueSave(select, { kind, holidayType, staffDayTimeOptionId })
   }
 
   queueSave(select, payload) {
@@ -73,9 +101,10 @@ export default class extends Controller {
     const date = select.dataset.date
 
     const kind = payload && payload.kind ? payload.kind : select.value
+    const holidayType =
+      (payload && payload.holidayType) ? payload.holidayType : null
     const staffDayTimeOptionId =
       (payload && payload.staffDayTimeOptionId) ? payload.staffDayTimeOptionId : null
-
 
     const row = select.closest(".shift-edit-row")
     const display = row ? row.querySelector(".shift-edit-display") : null
@@ -99,6 +128,7 @@ export default class extends Controller {
           date: date,
           staff_id: staffId,
           kind: kind,
+          holiday_type: holidayType,
           staff_day_time_option_id: staffDayTimeOptionId
         })
       })

--- a/app/models/staff_holiday_request.rb
+++ b/app/models/staff_holiday_request.rb
@@ -2,6 +2,12 @@ class StaffHolidayRequest < ApplicationRecord
   belongs_to :shift_month
   belongs_to :staff
 
+  enum :holiday_type, {
+    admin_off: 0,
+    requested_off: 1,
+    paid_leave: 2
+  }
+
   validates :date, presence: true
   validates :staff_id, uniqueness: { scope: [:shift_month_id, :date] }
 end

--- a/app/services/shift_drafts/stats_builder.rb
+++ b/app/services/shift_drafts/stats_builder.rb
@@ -41,6 +41,7 @@ module ShiftDrafts
 
       total_days = date_keys.length
       worked_days = Hash.new(0)
+      paid_leave_counts = Hash.new(0)
 
       date_keys.each do |dkey|
         kinds = @draft[dkey] || {}
@@ -64,6 +65,13 @@ module ShiftDrafts
         end
       end
 
+
+      @shift_month.staff_holiday_requests
+                  .where(date: month_begin..month_end, holiday_type: :paid_leave)
+                  .find_each do |request|
+        paid_leave_counts[request.staff_id.to_i] += 1
+      end
+
       required_holidays = @shift_month.holiday_days.to_i
 
       staff_ids.sort_by { |sid|
@@ -72,7 +80,7 @@ module ShiftDrafts
       }
       .map { |sid|
         staff = @staff_by_id[sid]
-        holiday_count = total_days - worked_days[sid]
+        holiday_count = total_days - worked_days[sid] - paid_leave_counts[sid]
         is_free = staff.respond_to?(:workday_constraint) && staff.workday_constraint == "free"
         holiday_shortage = is_free && required_holidays > 0 && holiday_count.to_i < required_holidays
         weekly_shortage_weeks = weekly_shortage_weeks_for(staff, dates, dayish_by_staff_and_date)
@@ -85,6 +93,7 @@ module ShiftDrafts
           late:  counts[sid][:late],
           night: counts[sid][:night],
           holiday: holiday_count,
+          paid_leave: paid_leave_counts[sid],
           holiday_shortage: holiday_shortage,
           weekly_shortage: weekly_shortage,
           weekly_shortage_weeks: weekly_shortage_weeks

--- a/app/services/shift_exports/mimosa_template_exporter.rb
+++ b/app/services/shift_exports/mimosa_template_exporter.rb
@@ -78,8 +78,9 @@ module ShiftExports
 
       # ---- style indexes ----
       red_style_index = read_cell(sheet, 2, col_index("U"))&.style_index # U2
-      holiday_request_style_index = read_cell(sheet, 221, col_index("L"))&.style_index # L221
-      base_date_style_index = read_cell(sheet, DATE_ROW_FIRST, MON_LEFT_COL)&.style_index
+      requested_off_style_index = read_cell(sheet, 221, col_index("L"))&.style_index # L221
+      paid_leave_style_index    = read_cell(sheet, 222, col_index("L"))&.style_index # L222
+      admin_off_style_index     = read_cell(sheet, 3, col_index("B"))&.style_index   # B3
 
       # ※日付セルは「元の背景/罫線/中央揃え」を維持し、赤はフォントだけ差し替える
       # （職員セルも同じ戦略で赤字にする）
@@ -171,7 +172,9 @@ module ShiftExports
             lines: day_lines,
             max_rows: limit,
             red_style_index: red_style_index,
-            holiday_request_style_index: holiday_request_style_index
+            requested_off_style_index: requested_off_style_index,
+            paid_leave_style_index: paid_leave_style_index,
+            admin_off_style_index: admin_off_style_index
           )
 
           write_lines_to_column(
@@ -360,14 +363,14 @@ module ShiftExports
               { text: s.last_name.to_s, red: false }
             end
           else
-            requested_holiday =
-              Array(holiday_requests_by_date[date]).any? { |request| request.staff_id.to_i == s.id.to_i }
+            holiday_request =
+              Array(holiday_requests_by_date[date]).find { |request| request.staff_id.to_i == s.id.to_i }
 
             # 休み（night_relatedは(休)を付けず赤字名前のみ）
             if night_related_ids.include?(s.id.to_i)
-              { text: s.last_name.to_s, red: true, holiday_request: false }
+              { text: s.last_name.to_s, red: true, holiday_type: nil }
             else
-              { text: "#{s.last_name}（休み）", red: true, holiday_request: requested_holiday }
+              { text: "#{s.last_name}（休み）", red: true, holiday_type: holiday_request&.holiday_type }
             end
           end
         end
@@ -432,13 +435,13 @@ module ShiftExports
         next if staff.nil?
         next unless row_key_for(staff) == row_key
 
-        requested_holiday =
-          Array(holiday_requests_by_date[date]).any? { |request| request.staff_id.to_i == staff.id.to_i }
+        holiday_request =
+          Array(holiday_requests_by_date[date]).find { |request| request.staff_id.to_i == staff.id.to_i }
 
         if night_related_ids.include?(staff.id.to_i)
-          lines << { text: staff.last_name.to_s, red: true, holiday_request: false }
+          lines << { text: staff.last_name.to_s, red: true, holiday_type: nil }
         else
-          lines << { text: "#{staff.last_name}（休み）", red: true, holiday_request: requested_holiday }
+          lines << { text: "#{staff.last_name}（休み）", red: true, holiday_type: holiday_request&.holiday_type }
         end
       end
 
@@ -498,7 +501,18 @@ module ShiftExports
     # -----------------------------
     # Excel書き込み（style保持 + 赤はフォントのみ）
     # -----------------------------
-    def write_lines_to_column(book:, sheet:, start_row:, col:, lines:, max_rows:, red_style_index:, holiday_request_style_index: nil)
+    def write_lines_to_column(
+      book:,
+      sheet:,
+      start_row:,
+      col:,
+      lines:,
+      max_rows:,
+      red_style_index:,
+      requested_off_style_index: nil,
+      paid_leave_style_index: nil,
+      admin_off_style_index: nil
+    )
       # まず、テンプレの枠（max_rows）に対して“空欄クリア”しておく
       max_rows.times do |i|
         cell = ensure_cell(sheet, start_row + i, col)
@@ -510,19 +524,31 @@ module ShiftExports
       Array(lines).first(max_rows).each_with_index do |item, i|
         text = item[:text].to_s
         red  = item[:red] == true
-        holiday_request = item[:holiday_request] == true
+        holiday_type = item[:holiday_type]
 
         cell = ensure_cell(sheet, start_row + i, col)
         next unless cell
 
         cell.change_contents(text)
 
-        if holiday_request && holiday_request_style_index
+        marker_style_index =
+          case holiday_type
+          when "requested_off"
+            requested_off_style_index
+          when "paid_leave"
+            paid_leave_style_index
+          when "admin_off"
+            admin_off_style_index
+          else
+            nil
+          end
+
+        if marker_style_index
           base_idx = cell.style_index
           fill_only_idx = build_fill_only_style_index(
             book: book,
             base_style_index: base_idx,
-            marker_style_index: holiday_request_style_index
+            marker_style_index: marker_style_index
           )
           cell.style_index = fill_only_idx if fill_only_idx
         end

--- a/app/views/shift_months/_draft_sidebar.html.erb
+++ b/app/views/shift_months/_draft_sidebar.html.erb
@@ -10,6 +10,7 @@
         <th>遅番</th>
         <th>夜勤</th>
         <th>休日</th>
+        <th>有休</th>
       </tr>
     </thead>
     <tbody>
@@ -37,6 +38,7 @@
           <td class="<%= row[:holiday_shortage] ? 'bg-danger-subtle text-danger fw-bold' : '' %>">
             <%= row[:holiday] %>
           </td>
+          <td><%= row[:paid_leave] %></td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/shift_months/_right_sidebar.html.erb
+++ b/app/views/shift_months/_right_sidebar.html.erb
@@ -101,9 +101,20 @@
                         max: @month_end.iso8601,
                         class: "form-control form-control-sm" %>
                 </div>
-                <div>
-                  <%= submit_tag "+追加", class: "btn btn-sm btn-light border" %>
+
+                <div style="min-width: 90px;">
+                  <%= select_tag :holiday_type,
+                        options_for_select([
+                          ["休み", "admin_off"],
+                          ["希望休", "requested_off"],
+                          ["有休", "paid_leave"]
+                        ], "requested_off"),
+                        class: "form-select form-select-sm" %>
                 </div>
+              </div>
+
+              <div class="d-flex justify-content-end mt-2">
+                <%= submit_tag "+追加", class: "btn btn-sm btn-light border" %>
               </div>
             </div>
           <% end %>
@@ -115,7 +126,21 @@
               <ul class="list-unstyled small">
                 <% @selected_staff_holidays.each do |request| %>
                   <li class="d-flex justify-content-between align-items-center mb-1">
-                    <span><%= request.date.strftime("%-m/%-d") %></span>
+                    <span>
+                      <%= request.date.strftime("%-m/%-d") %>
+                      <% label =
+                           case request.holiday_type
+                           when "admin_off"
+                            "休み"
+                          when "requested_off"
+                            "希望休"
+                          when "paid_leave"
+                            "有休"
+                          else
+                            "休み"
+                          end %>
+                      <span class="ms-1 text-muted">(<%= label %>)</span>
+                    </span>
 
                     <%= button_to "削除",
                                   remove_staff_holiday_shift_month_path(@shift_month, request_id: request.id),

--- a/app/views/shift_months/calendar_cells/_day_slot_body.html.erb
+++ b/app/views/shift_months/calendar_cells/_day_slot_body.html.erb
@@ -78,20 +78,42 @@
         ""
       end %>
 
-     <% requested_holiday =
-         Array((holiday_requests_by_date || {})[date]).any? { |request| request.staff_id.to_i == s.id.to_i } %>
+     <% holiday_request =
+         Array((holiday_requests_by_date || {})[date]).find { |request| request.staff_id.to_i == s.id.to_i } %>
 
     <% off_text =
         if selected == "off"
-          requested_holiday ? "(希望休)" : "(休)"
+          case holiday_request&.holiday_type
+          when "requested_off"
+            "(希望休)"
+          when "paid_leave"
+            "(有休)"
+          else
+            "(休)"
+          end
         else
           ""
         end %>
     <% night_related_class = (selected == "night_related") ? "text-danger" : "" %>
+    <% holiday_css_class =
+     if selected == "off"
+       case holiday_request&.holiday_type
+       when "admin_off"
+         "holiday-in-slot holiday-admin-off"
+       when "requested_off"
+         "holiday-in-slot holiday-requested-off"
+       when "paid_leave"
+         "holiday-in-slot holiday-paid-leave"
+       else
+         ""
+       end
+     else
+       ""
+     end %>
 
     <div class="shift-edit-row" data-controller="shift-edit">
       <div class="shift-edit-display <%= (selected == "off") ? "is-off" : "" %>">
-        <span class="shift-edit-name <%= night_related_class %>"><%= s.last_name %><%= off_text %></span>
+        <span class="shift-edit-name <%= night_related_class %> <%= holiday_css_class %>"><%= s.last_name %><%= off_text %></span>
         <% if time_text.present? %>
           <span class="shift-edit-time"><%= time_text %></span>
         <% end %>
@@ -129,8 +151,16 @@
             <%= s.last_name %>(11-20)
           </option>
 
-          <option value="off" <%= "selected" if selected == "off" %>>
+          <option value="off" <%= "selected" if selected == "off" && holiday_request.blank? %>>
             <%= s.last_name %>(休)
+          </option>
+
+          <option value="off:requested_off" <%= "selected" if selected == "off" && holiday_request&.requested_off? %>>
+            <%= s.last_name %>(希望休)
+          </option>
+
+          <option value="off:paid_leave" <%= "selected" if selected == "off" && holiday_request&.paid_leave? %>>
+            <%= s.last_name %>(有休)
           </option>
         </select>
       <% end %>

--- a/app/views/shift_months/calendar_cells/_preview.html.erb
+++ b/app/views/shift_months/calendar_cells/_preview.html.erb
@@ -96,14 +96,38 @@
             <div class="small"><%= s.last_name %></div>
           <% end %>
         <% else %>
-          <% requested_holiday =
-              Array((holiday_requests_by_date || {})[date]).any? { |request| request.staff_id.to_i == s.id.to_i } %>
+          <% holiday_request =
+              Array((holiday_requests_by_date || {})[date]).find { |request| request.staff_id.to_i == s.id.to_i } %>
+
+          <% label =
+               case holiday_request&.holiday_type
+               when "admin_off"
+                 "(休)"
+               when "requested_off"
+                 "(希望休)"
+               when "paid_leave"
+                 "(有休)"
+               else
+                 "(休)"
+               end %>
+
+          <% css_class =
+               case holiday_request&.holiday_type
+               when "admin_off"
+                 "small text-danger holiday-in-slot holiday-admin-off"
+               when "requested_off"
+                 "small text-danger holiday-in-slot holiday-requested-off"
+               when "paid_leave"
+                 "small text-danger holiday-in-slot holiday-paid-leave"
+               else
+                 "small text-danger"
+               end %>
 
           <% if night_related_ids.include?(s.id.to_i) %>
             <div class="small text-danger"><%= s.last_name %></div>
           <% else %>
-            <div class="small text-danger">
-              <%= s.last_name %><%= requested_holiday ? "(希望休)" : "(休)" %>
+            <div class="<%= css_class %>">
+              <%= s.last_name %><%= label %>
             </div>
           <% end %>
         <% end %>
@@ -175,10 +199,9 @@
           <% next if staff.nil? || !staff.active? %>
           <% next if night_related_ids.include?(staff.id.to_i) %>
           <% next unless row_key_for(staff) == row_key %>
-          <% requested_holiday =
-              Array((holiday_requests_by_date || {})[date]).any? { |request| request.staff_id.to_i == staff.id.to_i } %>
+
           <div class="small text-danger">
-            <%= staff.last_name %><%= requested_holiday ? "(希望休)" : "(休)" %>
+            <%= staff.last_name %>(休)
           </div>
         <% end %>
       <% end %>

--- a/app/views/shift_months/calendar_cells/_settings.html.erb
+++ b/app/views/shift_months/calendar_cells/_settings.html.erb
@@ -39,9 +39,33 @@
 
       <% requests = holiday_requests_by_date[date] || [] %>
       <% requests.each do |request| %>
-        <% if row_key_for(request.staff) == occupation[:key] %>
-          <div class="holiday-in-slot"><%= "#{request.staff.last_name} 希望休" %></div>
-        <% end %>
+        <% next unless row_key_for(request.staff) == occupation[:key] %>
+
+        <% label =
+            case request.holiday_type
+            when "admin_off"
+              "休"
+            when "requested_off"
+              "希望休"
+            when "paid_leave"
+              "有休"
+            else
+              "休"
+            end %>
+
+        <% css_class =
+            case request.holiday_type
+            when "admin_off"
+              "holiday-in-slot holiday-admin-off"
+            when "requested_off"
+              "holiday-in-slot"
+            when "paid_leave"
+              "holiday-in-slot holiday-paid-leave"
+            else
+              "holiday-in-slot"
+            end %>
+
+        <div class="<%= css_class %>"><%= "#{request.staff.last_name} #{label}" %></div>
       <% end %>
     </div>
 

--- a/app/views/shift_months/calendar_cells/_show.html.erb
+++ b/app/views/shift_months/calendar_cells/_show.html.erb
@@ -101,14 +101,38 @@
             <div class="small"><%= s.last_name %></div>
           <% end %>
         <% else %>
-          <% requested_holiday =
-            Array((holiday_requests_by_date || {})[date]).any? { |request| request.staff_id.to_i == s.id.to_i } %>
+          <% holiday_request =
+              Array((holiday_requests_by_date || {})[date]).find { |request| request.staff_id.to_i == s.id.to_i } %>
+
+          <% label =
+               case holiday_request&.holiday_type
+               when "admin_off"
+                 "(休)"
+               when "requested_off"
+                 "(希望休)"
+               when "paid_leave"
+                 "(有休)"
+               else
+                 "(休)"
+               end %>
+
+          <% css_class =
+               case holiday_request&.holiday_type
+               when "admin_off"
+                 "small text-danger holiday-in-slot holiday-admin-off"
+               when "requested_off"
+                 "small text-danger holiday-in-slot holiday-requested-off"
+               when "paid_leave"
+                 "small text-danger holiday-in-slot holiday-paid-leave"
+               else
+                 "small text-danger"
+               end %>
 
           <% if night_related_ids.include?(s.id.to_i) %>
             <div class="small text-danger"><%= s.last_name %></div>
           <% else %>
-            <div class="small text-danger">
-              <%= s.last_name %><%= requested_holiday ? "(希望休)" : "(休)" %>
+            <div class="<%= css_class %>">
+              <%= s.last_name %><%= label %>
             </div>
           <% end %>
         <% end %>
@@ -173,19 +197,13 @@
       <% if in_month %>
         <% unassigned_staffs = (unassigned_display_staffs_by_date && unassigned_display_staffs_by_date[date]) || [] %>
         <% unassigned_staffs.each do |staff| %>
-          <% next if staff.nil? %>
+          <% next if staff.nil? || !staff.active? %>
+          <% next if night_related_ids.include?(staff.id.to_i) %>
           <% next unless row_key_for(staff) == row_key %>
 
-          <% requested_holiday =
-              Array((holiday_requests_by_date || {})[date]).any? { |request| request.staff_id.to_i == staff.id.to_i } %>
-
-          <% if night_related_ids.include?(staff.id.to_i) %>
-            <div class="small text-danger"><%= staff.last_name %></div>
-          <% else %>
-            <div class="small text-danger">
-              <%= staff.last_name %><%= requested_holiday ? "(希望休)" : "(休)" %>
-            </div>
-          <% end %>
+          <div class="small text-danger">
+            <%= staff.last_name %>(休)
+          </div>
         <% end %>
       <% end %>
     <% end %>

--- a/db/migrate/20260412074421_add_holiday_type_to_staff_holiday_requests.rb
+++ b/db/migrate/20260412074421_add_holiday_type_to_staff_holiday_requests.rb
@@ -1,0 +1,5 @@
+class AddHolidayTypeToStaffHolidayRequests < ActiveRecord::Migration[8.1]
+  def change
+    add_column :staff_holiday_requests, :holiday_type, :integer, null: false, default: 1
+  end
+end

--- a/db/migrate/20260412080531_change_default_holiday_type_on_staff_holiday_requests.rb
+++ b/db/migrate/20260412080531_change_default_holiday_type_on_staff_holiday_requests.rb
@@ -1,0 +1,5 @@
+class ChangeDefaultHolidayTypeOnStaffHolidayRequests < ActiveRecord::Migration[8.1]
+  def change
+    change_column_default :staff_holiday_requests, :holiday_type, from: 1, to: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_05_093607) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_12_080531) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -178,6 +178,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_05_093607) do
   create_table "staff_holiday_requests", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.date "date", null: false
+    t.integer "holiday_type", default: 0, null: false
     t.bigint "shift_month_id", null: false
     t.bigint "staff_id", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
以下を実装しました
settingページ
・休/希望休/有休の選択肢を追加
・休みの種類に応じてシフト表に背景色付きで表示

edit_draftページ
・有休/希望休を選択できるように追加
・職員状況表に有休カウントの欄を追加

エクセル出力
・有休と希望休をわかるように表示
