### PR TITLE
add:スタッフ削除を完全削除へ変更

### DIFF
--- a/app/controllers/staffs_controller.rb
+++ b/app/controllers/staffs_controller.rb
@@ -4,12 +4,9 @@ class StaffsController < ApplicationController
   before_action :set_occupations, only: [:new, :create, :edit, :update]
 
   def index
-    @staffs = current_user.staffs.includes(:occupation, :staff_workable_wdays, :staff_unworkable_wdays, :staff_day_time_options).order(:last_name_kana, :first_name_kana) # orderはカナ順の表示
-    @used_staff_ids = 
-      ShiftDayAssignment.where(staff_id: @staffs.select(:id))
-                        .distinct
-                        .pluck(:staff_id)
-                        .to_set
+    @staffs = current_user.staffs
+                          .includes(:occupation, :staff_workable_wdays, :staff_unworkable_wdays, :staff_day_time_options)
+                          .order(:last_name_kana, :first_name_kana) # orderはカナ順の表示
   end
 
   def new
@@ -65,13 +62,8 @@ class StaffsController < ApplicationController
   end
 
   def destroy
-    if @staff.shift_day_assignments.exists?
-      @staff.update!(active: false)
-      redirect_to staffs_path, notice: "過去のシフトに使用されているため、退職（無効化）にしました"
-    else
-      @staff.destroy!
-      redirect_to staffs_path, notice: "職員を削除しました"
-    end
+    @staff.destroy!
+    redirect_to staffs_path, notice: "職員を削除しました"
   end
 
   def restore

--- a/app/models/staff.rb
+++ b/app/models/staff.rb
@@ -1,9 +1,10 @@
 class Staff < ApplicationRecord
   belongs_to :occupation
   belongs_to :user
-  has_many :shift_day_assignments, dependent: :restrict_with_exception # 間違ってdestroyしてもRails側で止める
+  has_many :shift_day_assignments, dependent: :destroy
   has_many :staff_workable_wdays, dependent: :destroy
-  has_many :shift_day_designations, dependent: :restrict_with_exception
+  has_many :shift_day_designations, dependent: :destroy
+  has_many :staff_holiday_requests, dependent: :destroy
   has_many :staff_unworkable_wdays, dependent: :destroy
   has_many :staff_day_time_options, -> { order(:position) }, dependent: :destroy
   has_one  :default_day_time_option,

--- a/app/views/staffs/index.html.erb
+++ b/app/views/staffs/index.html.erb
@@ -33,7 +33,6 @@
           <tbody class="text-center">
             <% if @staffs.any? %>
               <% @staffs.each do |staff| %>
-                <% used = @used_staff_ids&.include?(staff.id) %>
 
                 <tr>
                   <td class= "text-center">
@@ -44,38 +43,19 @@
                                   class: "btn btn-outline-secondary btn-sm px-1 py-0",
                                   form_class: "d-inline m-0" %>
 
-                      <% if staff.active? %>
-                        <% if used %>
-                          <%= button_to "退職",
-                                        staff_path(staff),
-                                        method: :delete,
-                                        form: { data: { turbo_confirm: "過去のシフトは残したまま、退職（無効化）にします。よろしいですか？" } },
-                                        class: "btn btn-outline-danger btn-sm px-1 py-0",
-                                        form_class: "d-inline m-0" %>
-                        <% else %>
-                          <%= button_to "削除",
-                                        staff_path(staff),
-                                        method: :delete,
-                                        form: { data: { turbo_confirm: "この職員はまだシフトに使用されていません。削除しますか？" } },
-                                        class: "btn btn-outline-danger btn-sm px-1 py-0",
-                                        form_class: "d-inline m-0" %>
-                        <% end %>
-                      <% else %>
-                        <%= button_to "復職",
-                                      restore_staff_path(staff),
-                                      method: :patch,
-                                      form: { data: {turbo_confirm: "この職員を復職させますか？" } },
-                                      class: "btn btn-outline-success btn-sm px-1 py-0",
-                                      form_class: "d-inline m-0" %>
-                      <% end %>
+
+                      <%= button_to "削除",
+                                    staff_path(staff),
+                                    method: :delete,
+                                    form: { data: { turbo_confirm: "この職員を完全に削除します。過去のシフトなどこの職員に関する設定は全て削除されます。よろしいですか？" } },
+                                    class: "btn btn-outline-danger btn-sm px-1 py-0",
+                                    form_class: "d-inline m-0" %>
+
                     </div>
                   </td>
 
                   <td>
                     <%= "#{staff.last_name} #{staff.first_name}" %>
-                    <% unless staff.active %>
-                      <span class="badge text-bg-secondary ms-1">退職</span>
-                    <% end %>
                   </td>
                   <td><%= staff.occupation&.name || "未設定" %></td>
                   <td class="text-center small" style="white-space: nowrap;">

--- a/lib/tasks/staff_cleanup.rake
+++ b/lib/tasks/staff_cleanup.rake
@@ -1,0 +1,24 @@
+namespace :staff do
+  desc "退職運用で残っている inactive staff を完全削除する"
+  task purge_inactive: :environment do
+    staffs = Staff.where(active: false)
+
+    puts "対象件数: #{staffs.count}件"
+
+    staffs.find_each do |staff|
+      ActiveRecord::Base.transaction do
+        ShiftDayAssignment.where(staff_id: staff.id)
+                          .update_all(staff_day_time_option_id: nil, updated_at: Time.current)
+
+        puts "削除開始: staff_id=#{staff.id} #{staff.last_name} #{staff.first_name}"
+        staff.destroy!
+        puts "削除完了: staff_id=#{staff.id}"
+      end
+    rescue => e
+      puts "削除失敗: staff_id=#{staff.id} error=#{e.class} #{e.message}"
+      raise
+    end
+
+    puts "完了"
+  end
+end


### PR DESCRIPTION
スタッフの削除が、過去にシフト作成でデータが使われていると残るようになっていたが、完全削除に仕様変更しました。