### PR TITLE
add:曜日固定勤務の職員に人員配置設定の人員に含める・含めないの属性を追加

### DIFF
--- a/app/controllers/staffs_controller.rb
+++ b/app/controllers/staffs_controller.rb
@@ -105,6 +105,7 @@ class StaffsController < ApplicationController
       :workday_constraint,
       :assignment_policy,
       :weekly_workdays,
+      :count_fixed_in_weekday_requirements,
       staff_day_time_options_attributes: [
         :id,
         :time_text,

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -7,6 +7,7 @@ function updateWorkdayConstraintUI(value) {
   const workable    = document.getElementById("workable-wdays-fieldset");
   const unworkable  = document.getElementById("unworkable-wdays-fieldset");
   const weeklyField = document.getElementById("weekly-workdays-field");
+  const fixedCountFieldset = document.getElementById("count-fixed-in-weekday-requirements-fieldset")
 
   const isFixed  = (value === "fixed");
   const isFree   = (value === "free");
@@ -16,6 +17,16 @@ function updateWorkdayConstraintUI(value) {
     workable.disabled = !isFixed;
     workable.classList.toggle("is-enabled", isFixed);
     workable.classList.toggle("is-disabled", !isFixed);
+  }
+
+  if (fixedCountFieldset) {
+    fixedCountFieldset.disabled = !isFixed
+    fixedCountFieldset.classList.toggle("is-enabled", isFixed)
+    fixedCountFieldset.classList.toggle("is-disabled", !isFixed)
+
+    fixedCountFieldset.querySelectorAll('input[type="radio"]').forEach((radio) => {
+      radio.disabled = !isFixed
+    })
   }
 
   const enableUnworkable = isFree;

--- a/app/models/staff.rb
+++ b/app/models/staff.rb
@@ -116,4 +116,14 @@ class Staff < ApplicationRecord
       end
     end
   end
+
+  def counts_toward_requirements?
+    return true unless workday_constraint.to_s == "fixed"
+
+    count_fixed_in_weekday_requirements?
+  end
+
+  def counts_toward_weekday_requirements?
+    counts_toward_requirements?
+  end
 end

--- a/app/services/shift_drafts/alerts_builder.rb
+++ b/app/services/shift_drafts/alerts_builder.rb
@@ -272,6 +272,8 @@ module ShiftDrafts
 
         staff = @staff_by_id[sid.to_i]
         next if staff.nil?
+        next unless staff.counts_toward_requirements?
+
         occ_name = staff.occupation&.name.to_s
 
         nurse += 1 if occ_name.include?("看護")
@@ -293,6 +295,7 @@ module ShiftDrafts
 
         staff = @staff_by_id[sid.to_i]
         next if staff.nil?
+        next unless staff.counts_toward_requirements?
 
         drive += 1 if staff.respond_to?(:can_drive) && staff.can_drive
         cook  += 1 if staff.respond_to?(:can_cook)  && staff.can_cook

--- a/app/services/shift_drafts/random_generator.rb
+++ b/app/services/shift_drafts/random_generator.rb
@@ -101,7 +101,7 @@ module ShiftDrafts
 
             fixed_staffs = scope
               .where(can_day: true)
-              .where(assignment_policy: :required)
+              .where(workday_constraint: :fixed)
               .left_joins(:staff_workable_wdays)
               .where(staff_workable_wdays: { wday: ShiftMonth.ui_wday(date) })
               .where.not(id: holiday_ids + forced_off_ids)
@@ -109,7 +109,6 @@ module ShiftDrafts
               .includes(:occupation)
 
             day_rows = Array(day_hash[:day])
-            slot = day_rows.size
 
             fixed_staffs.each do |staff|
               add_row_and_track!(
@@ -133,9 +132,13 @@ module ShiftDrafts
               slot: slot
             )
 
-            current_staff_ids = day_rows.map { |r| r[:staff_id] }.compact.map(&:to_i)
-            have_nurse = current_staff_ids.count { |sid| occ_name_by_staff_id[sid].to_s.include?("看護") }
-            have_care  = current_staff_ids.count { |sid| occ_name_by_staff_id[sid].to_s.include?("介護") }
+            uncounted_fixed_ids =
+              fixed_staffs.reject(&:counts_toward_requirements?).map(&:id)
+            current_counted_staff_ids =
+              day_rows.map { |r| r[:staff_id] }.compact.map(&:to_i) - uncounted_fixed_ids
+
+            have_nurse = current_counted_staff_ids.count { |sid| occ_name_by_staff_id[sid].to_s.include?("看護") }
+            have_care  = current_counted_staff_ids.count { |sid| occ_name_by_staff_id[sid].to_s.include?("介護") }
 
             need_nurse = [counts[:nurse] - have_nurse, 0].max
             need_care  = [counts[:care]  - have_care,  0].max
@@ -330,12 +333,18 @@ module ShiftDrafts
     def fill_day_skills!(day_rows:, date:, skill_counts:, assigned_today:, holiday_ids:, scope:, slot:)
       day_staff_ids = day_rows.map { |row| row[:staff_id] }.compact.map(&:to_i)
 
-      drive_have = 0
-      cook_have  = 0
-      if day_staff_ids.any?
-        drive_have = scope.where(id: day_staff_ids, can_drive: true).count
-        cook_have  = scope.where(id: day_staff_ids, can_cook:  true).count
-      end
+      counted_day_staffs =
+        if day_staff_ids.any?
+          scope
+            .where(id: day_staff_ids)
+            .includes(:occupation)
+            .reject { |staff| !staff.counts_toward_requirements? }
+        else
+          []
+        end
+
+      drive_have = counted_day_staffs.count { |staff| staff.respond_to?(:can_drive) && staff.can_drive }
+      cook_have  = counted_day_staffs.count { |staff| staff.respond_to?(:can_cook)  && staff.can_cook }
 
       need_drive = [skill_counts[:drive].to_i - drive_have, 0].max
       need_cook  = [skill_counts[:cook].to_i  - cook_have,  0].max

--- a/app/views/staffs/_form.html.erb
+++ b/app/views/staffs/_form.html.erb
@@ -86,28 +86,56 @@
 
         <div id="fixed-group" class="d-flex align-items-start flex-wrap gap-3">
           <label class="d-flex align-items-center gap-1 mb-0 mt-1"
-                 style="min-width: 100px;">
+                style="min-width: 100px;">
             <%= f.radio_button :workday_constraint, "fixed",
                     checked: @staff.workday_constraint == "fixed",
                     data: { action: "change->workdayConstraint" } %>
             出勤日固定
           </label>
 
-          <fieldset
-            id="workable-wdays-fieldset"
-            class="mt-2 workable-wdays <%= fixed ? "is-enabled" : "is-disabled" %>"
-            <%= "disabled" unless fixed %>>
-            <div class="small text-muted mb-1">出勤日</div>
+          <div class="mt-2">
+            <fieldset
+              id="workable-wdays-fieldset"
+              class="workable-wdays <%= fixed ? "is-enabled" : "is-disabled" %>"
+              <%= "disabled" unless fixed %>>
+              <div class="small text-muted mb-1">出勤日</div>
 
-            <div class="d-flex flex-wrap gap-2 small">
-              <% 7.times do |i| %>
-                <label class="d-flex align-items-center gap-1">
-                  <%= check_box_tag "staff[workable_wdays][]", i, checked_workable.include?(i) %>
-                  <%= wdays[i] %>
-                </label>
-              <% end %>
-            </div>
-          </fieldset>
+              <div class="d-flex flex-wrap gap-2 small">
+                <% 7.times do |i| %>
+                  <label class="d-flex align-items-center gap-1">
+                    <%= check_box_tag "staff[workable_wdays][]", i, checked_workable.include?(i) %>
+                    <%= wdays[i] %>
+                  </label>
+                <% end %>
+              </div>
+            </fieldset>
+
+            <fieldset
+              id="count-fixed-in-weekday-requirements-fieldset"
+              class="mt-2 small workable-wdays <%= fixed ? "is-enabled" : "is-disabled" %>"
+              <%= "disabled" unless fixed %>>
+
+              <div class="form-check">
+                <%= f.radio_button :count_fixed_in_weekday_requirements,
+                    true,
+                    class: "form-check-input",
+                    disabled: !fixed %>
+                <%= f.label :count_fixed_in_weekday_requirements_true,
+                    "曜日別人員配置の人数に含める",
+                    class: "form-check-label small" %>
+              </div>
+
+              <div class="form-check">
+                <%= f.radio_button :count_fixed_in_weekday_requirements,
+                    false,
+                    class: "form-check-input",
+                    disabled: !fixed %>
+                <%= f.label :count_fixed_in_weekday_requirements_false,
+                    "曜日別人員配置の人数に含めない",
+                    class: "form-check-label small" %>
+              </div>
+            </fieldset>
+          </div>
         </div>
         <div id="weekly-group" class="d-flex align-items-start flex-wrap gap-3">
           <label class="d-flex align-items-center gap-1 mb-0 mt-1"

--- a/app/views/staffs/index.html.erb
+++ b/app/views/staffs/index.html.erb
@@ -74,7 +74,7 @@
                     <%= "#{staff.last_name} #{staff.first_name}" %>
                   </td>
                   <td><%= staff.occupation&.name || "未設定" %></td>
-                  <td class="text-center small" style="white-space: nowrap;">
+                  <td class="text-center small">
                     <% wdays = %w[月 火 水 木 金 土 日] %>
 
                     <% if staff.workday_constraint == "free" %>
@@ -83,26 +83,36 @@
                         -
                         <% if ng.any? %>
                           <span class="small text-muted">
-                          ❎<%= ng.map { |i| "#{wdays[i]}" }.join %>
+                            ❎<%= ng.map { |i| wdays[i] }.join %>
                           </span>
                         <% end %>
                       </span>
+
                     <% elsif staff.workday_constraint == "weekly" %>
                       <% ng = staff.staff_unworkable_wdays.map(&:wday).sort %>
 
-                      <span class="small">
+                      <div class="small">
                         週<%= staff.weekly_workdays %>日
-                      </span>
+                      </div>
 
                       <% if ng.any? %>
-                        <span class="small text-muted">
+                        <div class="small text-muted">
                           ❎<%= ng.map { |i| wdays[i] }.join %>
-                        </span>
+                        </div>
                       <% end %>
 
                     <% else %>
                       <% selected = staff.staff_workable_wdays.map(&:wday).sort %>
-                      <span><%= selected.map { |i| wdays[i] }.join %></span> 
+
+                      <div>
+                        <%= selected.map { |i| wdays[i] }.join %>
+                      </div>
+
+                      <% unless staff.counts_toward_weekday_requirements? %>
+                        <div class="small text-muted">
+                          人数に含めない
+                        </div>
+                      <% end %>
                     <% end %>
                   </td>
 

--- a/db/migrate/20260614083931_add_count_fixed_in_weekday_requirements_to_staffs.rb
+++ b/db/migrate/20260614083931_add_count_fixed_in_weekday_requirements_to_staffs.rb
@@ -1,0 +1,5 @@
+class AddCountFixedInWeekdayRequirementsToStaffs < ActiveRecord::Migration[8.1]
+  def change
+    add_column :staffs, :count_fixed_in_weekday_requirements, :boolean, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_24_010740) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_14_083931) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -231,6 +231,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_24_010740) do
     t.boolean "can_late", default: false, null: false
     t.boolean "can_night", default: false, null: false
     t.boolean "can_visit", default: false, null: false
+    t.boolean "count_fixed_in_weekday_requirements", default: true, null: false
     t.datetime "created_at", null: false
     t.string "first_name", null: false
     t.string "first_name_kana", null: false


### PR DESCRIPTION
曜日固定勤務の職員に関して以下の仕様を追加
- 人員配置設定の人員に含める/含めないを設定できるようにしました。これにより、人員配置の人数・スキル人数の設定にはカウントされなくなりました。
- シフト生成に反映されるようになりました