### PR TITLE
add:最大連勤日数の設定を実装

### DIFF
--- a/app/controllers/staffs_controller.rb
+++ b/app/controllers/staffs_controller.rb
@@ -106,6 +106,7 @@ class StaffsController < ApplicationController
       :assignment_policy,
       :weekly_workdays,
       :count_fixed_in_weekday_requirements,
+      :max_consecutive_work_days,
       staff_day_time_options_attributes: [
         :id,
         :time_text,

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -7,7 +7,9 @@ function updateWorkdayConstraintUI(value) {
   const workable    = document.getElementById("workable-wdays-fieldset");
   const unworkable  = document.getElementById("unworkable-wdays-fieldset");
   const weeklyField = document.getElementById("weekly-workdays-field");
-  const fixedCountFieldset = document.getElementById("count-fixed-in-weekday-requirements-fieldset")
+  const fixedCountFieldset = document.getElementById("count-fixed-in-weekday-requirements-fieldset");
+  const maxConsecutiveGroup = document.getElementById("max-consecutive-work-days-group");
+  const maxConsecutiveSelect = document.getElementById("staff_max_consecutive_work_days");
 
   const isFixed  = (value === "fixed");
   const isFree   = (value === "free");
@@ -35,6 +37,15 @@ function updateWorkdayConstraintUI(value) {
     unworkable.disabled = !enableUnworkable;
     unworkable.classList.toggle("is-enabled", enableUnworkable);
     unworkable.classList.toggle("is-disabled", !enableUnworkable);
+  }
+
+  if (maxConsecutiveGroup) {
+    maxConsecutiveGroup.classList.toggle("is-enabled", isFree);
+    maxConsecutiveGroup.classList.toggle("is-disabled", !isFree);
+  }
+
+  if (maxConsecutiveSelect) {
+    maxConsecutiveSelect.disabled = !isFree;
   }
 
   if (weeklyField) {

--- a/app/models/staff.rb
+++ b/app/models/staff.rb
@@ -65,6 +65,13 @@ class Staff < ApplicationRecord
   validate :only_one_day_time_default_in_form
   validate :day_time_option_apply_wdays_must_not_overlap
 
+  validates :max_consecutive_work_days,
+          numericality: {
+            only_integer: true,
+            greater_than_or_equal_to: 1,
+            less_than_or_equal_to: 5
+          }
+
   class << self
     def human_attribute_name(attr, options = {})
       key = attr.to_s

--- a/app/services/shift_drafts/alerts_builder.rb
+++ b/app/services/shift_drafts/alerts_builder.rb
@@ -109,9 +109,11 @@ module ShiftDrafts
           if worked_dayish?(sid, date)
             streak += 1
 
-            # 6日目以降に表示
-            if streak == 6
-              (alerts[date] ||= []) << "#{staff_label(sid)}5連勤超"
+            max_days = max_consecutive_work_days_for(sid)
+
+            # 個別の最大連勤日数を超えた日に表示
+            if streak == max_days + 1
+              (alerts[date] ||= []) << "#{staff_label(sid)}#{max_days}連勤超"
             end
 
             # 5連勤に到達した日に、翌日/翌々日の「２連休が成立しているか」チェック
@@ -310,6 +312,15 @@ module ShiftDrafts
 
       v = row["staff_id"] || row[:staff_id]
       v.present? ? v.to_i : nil
+    end
+
+    def max_consecutive_work_days_for(staff_id)
+      staff = @staff_by_id[staff_id.to_i]
+      return 5 if staff.nil?
+      return 5 unless staff.workday_constraint.to_s == "free"
+
+      days = staff.max_consecutive_work_days.to_i
+      days.clamp(1, 5)
     end
   end
 end

--- a/app/services/shift_drafts/random_generator.rb
+++ b/app/services/shift_drafts/random_generator.rb
@@ -314,7 +314,9 @@ module ShiftDrafts
           candidate_ids.reject do |sid|
             before = @timeline.consecutive_day_count_before(sid, date)
             after  = consecutive_designation_days_after(sid, date)
-            (before + 1 + after) > 5
+            max_days = max_consecutive_work_days_for(sid)
+
+            (before + 1 + after) > max_days
           end
       end
 
@@ -704,6 +706,15 @@ module ShiftDrafts
 
         assigned_dayish_count_in_week(sid, date) >= limit
       end
+    end
+
+    def max_consecutive_work_days_for(staff_id)
+      staff = @staff_by_id[staff_id.to_i]
+      return 5 if staff.nil?
+      return 5 unless staff.workday_constraint.to_s == "free"
+
+      days = staff.max_consecutive_work_days.to_i
+      days.clamp(1, 5)
     end
 
     def assigned_kind_count_in_week(staff_id, date, kind)

--- a/app/views/staffs/_form.html.erb
+++ b/app/views/staffs/_form.html.erb
@@ -58,7 +58,7 @@
         <% fixed = (@staff.workday_constraint == "fixed") %>
         <% free  = !fixed %>
 
-        <div id="free-group" class="d-flex align-items-start flex-wrap gap-3">
+        <div id="free-group" class="d-flex align-items-start gap-3">
           <label class="d-flex align-items-center gap-1 mb-0 mt-1"
                  style="min-width: 100px;">
             <%= f.radio_button :workday_constraint, "free",
@@ -67,21 +67,35 @@
             制限なし
           </label>
 
-          <fieldset
-            id="unworkable-wdays-fieldset"
-            class="mt-2 workable-wdays <%= free ? "is-enabled" : "is-disabled" %>"
-            <%= "disabled" unless free %>>
-            <div class="small text-muted mb-1">勤務除外</div>
+          <div class="mt-2">
+            <fieldset
+              id="unworkable-wdays-fieldset"
+              class="workable-wdays <%= free ? "is-enabled" : "is-disabled" %>"
+              <%= "disabled" unless free %>>
+              <div class="small text-muted mb-1">勤務除外</div>
 
-            <div class="d-flex flex-wrap gap-2 small">
-              <% 7.times do |i| %>
-                <label class="d-flex align-items-center gap-1">
-                  <%= check_box_tag "staff[unworkable_wdays][]", i, checked_unworkable.include?(i) %>
-                  <%= wdays[i] %>
-                </label>
-              <% end %>
+              <div class="d-flex flex-wrap gap-2 small">
+                <% 7.times do |i| %>
+                  <label class="d-flex align-items-center gap-1">
+                    <%= check_box_tag "staff[unworkable_wdays][]", i, checked_unworkable.include?(i) %>
+                    <%= wdays[i] %>
+                  </label>
+                <% end %>
+              </div>
+            </fieldset>
+
+            <div id="max-consecutive-work-days-group"
+                 class="mt-2 d-flex align-items-center gap-2 workable-wdays <%= free ? "is-enabled" : "is-disabled" %>">
+              <%= f.label :max_consecutive_work_days, "最大連勤日数", class: "form-label small mb-0 mt-1" %>
+
+              <%= f.select :max_consecutive_work_days,
+                  options_for_select((1..5).map { |n| ["#{n}日", n] }, @staff.max_consecutive_work_days || 5),
+                  {},
+                  class: "form-select form-select-sm",
+                  style: "width: 80px;",
+                  disabled: !free %>
             </div>
-          </fieldset>
+          </div>
         </div>
 
         <div id="fixed-group" class="d-flex align-items-start flex-wrap gap-3">

--- a/app/views/staffs/index.html.erb
+++ b/app/views/staffs/index.html.erb
@@ -79,14 +79,21 @@
 
                     <% if staff.workday_constraint == "free" %>
                       <% ng = staff.staff_unworkable_wdays.map(&:wday).sort %>
-                      <span class="text-muted">
+
+                      <div class="text-muted">
                         -
                         <% if ng.any? %>
                           <span class="small text-muted">
                             ❎<%= ng.map { |i| wdays[i] }.join %>
                           </span>
                         <% end %>
-                      </span>
+                      </div>
+
+                      <% if staff.max_consecutive_work_days.to_i != 5 %>
+                        <div class="small text-muted">
+                          最大<%= staff.max_consecutive_work_days %>連勤
+                        </div>
+                      <% end %>
 
                     <% elsif staff.workday_constraint == "weekly" %>
                       <% ng = staff.staff_unworkable_wdays.map(&:wday).sort %>

--- a/db/migrate/20260621011815_add_max_consecutive_work_days_to_staffs.rb
+++ b/db/migrate/20260621011815_add_max_consecutive_work_days_to_staffs.rb
@@ -1,0 +1,5 @@
+class AddMaxConsecutiveWorkDaysToStaffs < ActiveRecord::Migration[8.1]
+  def change
+    add_column :staffs, :max_consecutive_work_days, :integer, null: false, default: 5
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_14_083931) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_21_011815) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -237,6 +237,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_14_083931) do
     t.string "first_name_kana", null: false
     t.string "last_name", null: false
     t.string "last_name_kana", null: false
+    t.integer "max_consecutive_work_days", default: 5, null: false
     t.bigint "occupation_id", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false


### PR DESCRIPTION
職員登録で出勤形態で「制限なし」の人は、最大連勤日数を１〜５日で個別設定できるようにしました。