### PR TITLE
fix:連続勤務設定を修正、職員の勤務回数表の並び順を調整

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -333,6 +333,11 @@ body.sidebar-left-collapsed #sidebar-col {
   color: #666;
 }
 
+.staff-stats-table tr.weekly-staff-row > th,
+.staff-stats-table tr.weekly-staff-row > td {
+  background-color: #eef7ff;
+}
+
 /* =========================================
    edit_draft カレンダー内
 ========================================= */

--- a/app/services/shift_drafts/random_generator.rb
+++ b/app/services/shift_drafts/random_generator.rb
@@ -612,11 +612,16 @@ module ShiftDrafts
 
       return unless [:day, :early, :late].include?(kind)
 
-      #今日割当する直前までの連続日勤系数
-      before = @timeline.consecutive_day_count_before(staff_id.to_i, date)
+      # 今日割当後の連続日勤系数
+      sid = staff_id.to_i
+      before = @timeline.consecutive_day_count_before(sid, date)
+      streak_after_assignment = before + 1
+      max_days = max_consecutive_work_days_for(sid)
 
-      if before >= 4
-        lock_two_off_days!(staff_id.to_i, date: date, month_end: month_end)
+      if max_days >= 5 && streak_after_assignment >= 5
+        lock_two_off_days!(sid, date: date, month_end: month_end)
+      elsif max_days < 5 && streak_after_assignment >= max_days
+        lock_one_off_day!(sid, date: date, month_end: month_end)
       end
     end
 
@@ -625,6 +630,11 @@ module ShiftDrafts
       d2 = date + 2
       @forced_off_dates_by_staff_id[staff_id] << d1 if d1 <= month_end
       @forced_off_dates_by_staff_id[staff_id] << d2 if d2 <= month_end
+    end
+
+    def lock_one_off_day!(staff_id, date:, month_end:)
+      d1 = date + 1
+      @forced_off_dates_by_staff_id[staff_id] << d1 if d1 <= month_end
     end
 
     def lock_night_flow!(staff_id, date:, month_end:)

--- a/app/views/shift_months/_draft_sidebar.html.erb
+++ b/app/views/shift_months/_draft_sidebar.html.erb
@@ -16,14 +16,41 @@
     <tbody>
       <% sorted_rows =
           stats_rows
-            .select { |row| ( s = row[:staff]) && s.active? } 
+            .select { |row| (s = row[:staff]) && s.active? }
             .sort_by do |row|
-              c = row[:staff].workday_constraint.to_s
-              (c == "free" || c == "weekly") ? 0 : 1
+              staff = row[:staff]
+
+              constraint_order =
+                case staff.workday_constraint.to_s
+                when "free"
+                  0
+                when "weekly"
+                  1
+                when "fixed"
+                  2
+                else
+                  3
+                end
+
+              [
+                constraint_order,
+                staff.last_name_kana.to_s,
+                staff.first_name_kana.to_s,
+                staff.id.to_i
+              ]
             end
       %>
       <% sorted_rows.each do |row| %>
-        <tr class="<%= row[:staff].workday_constraint == 'fixed' ? 'fixed-staff-row' : '' %>">
+        <tr class="<%= 
+            case row[:staff].workday_constraint.to_s
+            when 'weekly'
+              'weekly-staff-row'
+            when 'fixed'
+              'fixed-staff-row'
+            else
+              ''
+            end
+          %>">
           <% weekly_shortage = row[:weekly_shortage] %>
           <% weekly_weeks = Array(row[:weekly_shortage_weeks]) %>
 


### PR DESCRIPTION
以下を修正・調整しています。
・連続勤務日数上限を５日未満に設定しているが、勤務の対象が早番・遅番がカウントに含まれていなかったため、勤務の対象は日勤、早番、遅番になるよう修正。
・シフト生成時に右サイドバーに表示される、職員の各勤務回数欄の並び順を調整。