### PR TITLE
add:勤務形態週○日の人のシフト生成調整

### DIFF
--- a/app/controllers/shift_months_controller.rb
+++ b/app/controllers/shift_months_controller.rb
@@ -1317,7 +1317,8 @@ end
     @stats_rows = ShiftDrafts::StatsBuilder.new(
       shift_month: @shift_month,
       staff_by_id: @staff_by_id,
-      draft: assignments_hash
+      draft: assignments_hash,
+      carry_over_state: @carry_over_state
     ).call
 
     alert_dates = (@month_begin..@month_end).to_a
@@ -1447,6 +1448,19 @@ end
     current_month_begin = Date.new(shift_month.year, shift_month.month, 1)
     prev_month_end = current_month_begin.prev_day
 
+    first_week_begin = current_month_begin.beginning_of_week(:monday)
+    first_week_prev_dates = (first_week_begin...current_month_begin).to_a
+
+    first_week_paid_leave_counts_by_staff_id =
+      if first_week_prev_dates.empty?
+        Hash.new(0)
+      else
+        StaffHolidayRequest
+          .where(date: first_week_prev_dates, holiday_type: :paid_leave)
+          .group(:staff_id)
+          .count
+      end
+
     state = {}
 
     history.each do |staff_id, by_date|
@@ -1495,10 +1509,20 @@ end
         end
       end
 
+      first_week_dayish_count =
+        first_week_prev_dates.count do |date|
+          Array(by_date[date]).any? { |kind| [:day, :early, :late].include?(kind) }
+        end
+
+      first_week_paid_leave_count =
+        first_week_paid_leave_counts_by_staff_id[staff_id].to_i
+
       state[staff_id] = {
         carry_in_kind: carry_in_kind,
         remaining_required_rest_days: remaining_required_rest_days,
-        carried_work_streak: work_streak
+        carried_work_streak: work_streak,
+        first_week_dayish_count: first_week_dayish_count,
+        first_week_paid_leave_count: first_week_paid_leave_counts_by_staff_id[staff_id].to_i
       }
     end
 

--- a/app/services/shift_drafts/random_generator.rb
+++ b/app/services/shift_drafts/random_generator.rb
@@ -4,6 +4,14 @@ module ShiftDrafts
       @shift_month = shift_month
       @active_scope = @shift_month.user.staffs.where(active: true)
       @carry_over_state = carry_over_state || {}
+      @first_week_dayish_counts_by_staff_id =
+        @carry_over_state.each_with_object(Hash.new(0)) do |(staff_id, state), hash|
+          hash[staff_id.to_i] = state[:first_week_dayish_count].to_i
+        end
+      @first_week_paid_leave_counts_by_staff_id =
+        @carry_over_state.each_with_object(Hash.new(0)) do |(staff_id, state), hash|
+          hash[staff_id.to_i] = state[:first_week_paid_leave_count].to_i
+        end
     end
 
     def call
@@ -735,6 +743,16 @@ module ShiftDrafts
       end
     end
 
+    def weekly_dayish_count_for_generation(staff_id, date)
+      count = assigned_dayish_count_in_week(staff_id, date)
+
+      month_begin = @dates.first
+      return count unless date.beginning_of_week(:monday) == month_begin.beginning_of_week(:monday)
+      return count if month_begin.monday?
+
+      count + @first_week_dayish_counts_by_staff_id[staff_id.to_i].to_i
+    end
+
     def adjust_weekly_day_shortages!(month_begin:, month_end:)
       weekly_staffs =
         @staff_by_id.values.select do |staff|
@@ -757,10 +775,18 @@ module ShiftDrafts
               staff_assigned_dayish_on?(sid, date)
             end
 
+          if first_week_dates?(week_dates)
+            actual += @first_week_dayish_counts_by_staff_id[sid].to_i
+          end
+
           paid_leave_count =
             week_dates.count do |date|
               paid_leave_on?(sid, date)
             end
+
+          if first_week_dates?(week_dates)
+            paid_leave_count += @first_week_paid_leave_counts_by_staff_id[sid].to_i
+          end
 
           required_workdays = [limit - paid_leave_count, 0].max
 
@@ -906,14 +932,27 @@ module ShiftDrafts
 
       while date <= last
         week_dates = (date..(date + 6)).to_a
+        in_month_dates = week_dates.select { |d| d.between?(month_begin, month_end) }
 
-        # monthly / weekly 補正では、月内に7日揃っている週だけ対象にする
-        ranges << week_dates if week_dates.all? { |d| d.between?(month_begin, month_end) }
+        if in_month_dates.present?
+          # 月末の不完全週は、翌月側を見ないので補正対象外
+          unless in_month_dates.include?(month_end) && in_month_dates.size < 7
+            # 月初の不完全週は、前月側の勤務数を使うため補正対象に含める
+            ranges << in_month_dates
+          end
+        end
 
         date += 7
       end
 
       ranges
+    end
+
+    def first_week_dates?(week_dates)
+      month_begin = @dates.first
+      return false if month_begin.monday?
+
+      week_dates.first == month_begin
     end
 
     def can_add_day_for_weekly_adjustment?(staff, date)
@@ -1063,7 +1102,7 @@ module ShiftDrafts
         limit = staff.weekly_workdays.to_i
         next false if limit <= 0
 
-        assigned_dayish_count_in_week(sid, date) >= weekly_required_workdays_for(staff, date)
+        weekly_dayish_count_for_generation(sid, date) >= weekly_required_workdays_for(staff, date)
       end
     end
 
@@ -1111,11 +1150,16 @@ module ShiftDrafts
 
       week_begin = date.beginning_of_week(:monday)
       week_end   = week_begin + 6
+      month_begin = @dates.first
 
       paid_leave_count =
         (week_begin..week_end).count do |d|
           @dates.include?(d) && paid_leave_on?(staff.id, d)
         end
+
+      if !month_begin.monday? && week_begin == month_begin.beginning_of_week(:monday)
+        paid_leave_count += @first_week_paid_leave_counts_by_staff_id[staff.id.to_i].to_i
+      end
 
       [limit - paid_leave_count, 0].max
     end

--- a/app/services/shift_drafts/stats_builder.rb
+++ b/app/services/shift_drafts/stats_builder.rb
@@ -1,9 +1,20 @@
 module ShiftDrafts
   class StatsBuilder
-    def initialize(shift_month:, staff_by_id:, draft:)
+    def initialize(shift_month:, staff_by_id:, draft:, carry_over_state: {})
       @shift_month = shift_month
       @staff_by_id = staff_by_id
       @draft = draft
+      @carry_over_state = carry_over_state || {}
+
+      @first_week_dayish_counts_by_staff_id =
+        @carry_over_state.each_with_object(Hash.new(0)) do |(staff_id, state), hash|
+          hash[staff_id.to_i] = state[:first_week_dayish_count].to_i
+        end
+
+      @first_week_paid_leave_counts_by_staff_id =
+        @carry_over_state.each_with_object(Hash.new(0)) do |(staff_id, state), hash|
+          hash[staff_id.to_i] = state[:first_week_paid_leave_count].to_i
+        end
     end
 
     def call
@@ -140,6 +151,13 @@ module ShiftDrafts
       ranges
     end
 
+    def first_week_dates?(dates_in_week, all_dates)
+      month_begin = all_dates.first
+      return false if month_begin.monday?
+
+      dates_in_week.first == month_begin
+    end
+
     def weekly_shortage_weeks_for(staff, dates, dayish_by_staff_and_date, paid_leave_by_staff_and_date)
       return [] unless staff&.workday_constraint.to_s == "weekly"
 
@@ -168,6 +186,11 @@ module ShiftDrafts
           in_month_dates.count do |d|
             paid_leave_by_staff_and_date.dig(sid, d) == true
           end
+
+        if first_week_dates?(in_month_dates, dates)
+          actual += @first_week_dayish_counts_by_staff_id[sid].to_i
+          paid_leave_count += @first_week_paid_leave_counts_by_staff_id[sid].to_i
+        end
 
         required_workdays = [limit - paid_leave_count, 0].max
 


### PR DESCRIPTION
以下を追加しています。
・月の第1週が前月と重なっている場合、勤務形態週○日の人は、前月の勤務日数も踏まえてシフト生成される。