### PR TITLE
add:同じ週の前の月の勤務が視認できるように調整

### DIFF
--- a/app/controllers/shift_months_controller.rb
+++ b/app/controllers/shift_months_controller.rb
@@ -161,6 +161,19 @@ class ShiftMonthsController < ApplicationController
     prepare_month_tab_vars
     @carry_over_state = build_carry_over_state(shift_month: @shift_month)
     @carry_over_source_assignments = previous_month_confirmed_assignments_for_carry_over(shift_month: @shift_month, days: 7).to_a
+    @previous_month_assignments_for_display =
+      build_assignments_hash(
+        previous_month_confirmed_assignments_for_carry_over(shift_month: @shift_month, days: 7)
+          .where(date: @calendar_begin...@month_begin)
+      )
+    @previous_month_unassigned_display_staffs_by_date =
+      ShiftDrafts::UnassignedDisplayStaffsBuilder
+        .new(
+          dates: (@calendar_begin...@month_begin).to_a,
+          staff_by_id: @staff_by_id,
+          assignments_hash: @previous_month_assignments_for_display
+        )
+        .call
     @weekday_requirements = build_weekday_requirements_hash
     @day_req = @shift_month.required_counts_for(@selected_date, shift_kind: :day)
     @day_skill_req = @shift_month.required_skill_counts_for(@selected_date)
@@ -1307,6 +1320,21 @@ end
     preload_staffs_for
     @carry_over_state = build_carry_over_state(shift_month: @shift_month)
 
+    @previous_month_assignments_for_display =
+      build_assignments_hash(
+        previous_month_confirmed_assignments_for_carry_over(shift_month: @shift_month, days: 7)
+          .where(date: @calendar_begin...@month_begin)
+      )
+
+    @previous_month_unassigned_display_staffs_by_date =
+      ShiftDrafts::UnassignedDisplayStaffsBuilder
+        .new(
+          dates: (@calendar_begin...@month_begin).to_a,
+          staff_by_id: @staff_by_id,
+          assignments_hash: @previous_month_assignments_for_display
+        )
+        .call
+
     @unassigned_display_staffs_by_date =
       ShiftDrafts::UnassignedDisplayStaffsBuilder
         .new(dates: @dates, staff_by_id: @staff_by_id, assignments_hash: assignments_hash)
@@ -1422,9 +1450,17 @@ end
     from_date = [prev_month_end - (days - 1), prev_month_begin].max
 
     prev_shift_month.shift_day_assignments
-                    .confirmed
-                    .where(date: from_date..prev_month_end)
-                    .select(:id, :date, :shift_kind, :staff_id, :slot)
+                .confirmed
+                .where(date: from_date..prev_month_end)
+                .select(
+                  :id,
+                  :date,
+                  :shift_kind,
+                  :staff_id,
+                  :slot,
+                  :staff_day_time_option_id,
+                  :shift_month_time_option_id
+                )
   end
 
   def build_carry_over_history_by_staff_and_date(assignments)

--- a/app/views/shift_months/_calendar.html.erb
+++ b/app/views/shift_months/_calendar.html.erb
@@ -18,7 +18,9 @@
 <% designations_by_date             = local_assigns.fetch(:designations_by_date, {}) || {} %>
 <% holiday_requests_by_date         = local_assigns.fetch(:holiday_requests_by_date, nil) %>
 <% unassigned_display_staffs_by_date = local_assigns.fetch(:unassigned_display_staffs_by_date, nil) %>
+<% previous_month_unassigned_display_staffs_by_date = local_assigns.fetch(:previous_month_unassigned_display_staffs_by_date, @previous_month_unassigned_display_staffs_by_date || {}) || {} %>
 <% carry_over_state                 = local_assigns.fetch(:carry_over_state, {}) || {} %>
+<% previous_month_assignments_for_display = local_assigns.fetch(:previous_month_assignments_for_display, @previous_month_assignments_for_display || {}) || {} %>
 <% extra                            = local_assigns[:extra_locals].is_a?(Hash) ? local_assigns[:extra_locals] : {} %>
 
 <div class="shift-calendar-scroll">
@@ -82,6 +84,10 @@
 
             <% week.each do |date| %>
               <% in_month = (date.month == shift_month.month) %>
+              <% cell_draft = in_month ? draft : previous_month_assignments_for_display %>
+              <% cell_saved = in_month ? saved : previous_month_assignments_for_display %>
+              <% cell_unassigned_display_staffs_by_date =
+                  in_month ? unassigned_display_staffs_by_date : previous_month_unassigned_display_staffs_by_date %>
 
               <td class="day-cell <%= in_month ? "" : "is-out" %>">
                 <%= render cell_partial,
@@ -97,12 +103,12 @@
                             required_by_date: required_by_date,
                             required_skill_by_date: required_skill_by_date,
                             staff_by_id: staff_by_id,
-                            draft: draft,
-                            saved: saved,
+                            draft: cell_draft,
+                            saved: cell_saved,
                             alerts_by_date: alerts_by_date,
                             designations_by_date: designations_by_date,
                             holiday_requests_by_date: holiday_requests_by_date,
-                            unassigned_display_staffs_by_date: unassigned_display_staffs_by_date,
+                            unassigned_display_staffs_by_date: cell_unassigned_display_staffs_by_date,
                             carry_over_state: carry_over_state
                           }.merge(extra) %>
               </td>

--- a/app/views/shift_months/calendar_cells/_settings.html.erb
+++ b/app/views/shift_months/calendar_cells/_settings.html.erb
@@ -17,6 +17,34 @@
 <% else %>
   <div class="day-slots">
     <div class="slot slot-day" data-shift-kind="day">
+      <% unless in_month %>
+        <% date_key = date.to_s %>
+
+        <% previous_day_rows = Array(draft&.dig(date_key, "day")) %>
+        <% previous_day_rows.each do |row| %>
+          <% s = staff_by_id[row["staff_id"].to_i] %>
+          <% next if s.blank? %>
+          <% next unless row_key_for(s) == row_key %>
+          <div class="small shift-line text-muted"><%= s.last_name %></div>
+        <% end %>
+
+        <% previous_early_rows = Array(draft&.dig(date_key, "early")) %>
+        <% previous_early_rows.each do |row| %>
+          <% s = staff_by_id[row["staff_id"].to_i] %>
+          <% next if s.blank? %>
+          <% next unless row_key_for(s) == row_key %>
+          <div class="small shift-line text-muted"><%= s.last_name %><span class="shift-time">730-1630</span></div>
+        <% end %>
+
+        <% previous_late_rows = Array(draft&.dig(date_key, "late")) %>
+        <% previous_late_rows.each do |row| %>
+          <% s = staff_by_id[row["staff_id"].to_i] %>
+          <% next if s.blank? %>
+          <% next unless row_key_for(s) == row_key %>
+          <div class="small shift-line text-muted"><%= s.last_name %><span class="shift-time">11-20</span></div>
+        <% end %>
+      <% end %>
+
       <% day_ids = Array(designations_by_date.dig(date, "day")).map(&:to_i) %>
       <% day_ids.each do |sid| %>
         <% s = staff_by_id[sid] %>
@@ -91,6 +119,18 @@
     </div>
 
     <div class="slot slot-night" data-shift-kind="night">
+      <% unless in_month %>
+        <% date_key = date.to_s %>
+
+        <% previous_night_rows = Array(draft&.dig(date_key, "night")) %>
+        <% previous_night_rows.each do |row| %>
+          <% s = staff_by_id[row["staff_id"].to_i] %>
+          <% next if s.blank? %>
+          <% next unless row_key_for(s) == row_key %>
+          <div class="small shift-line text-muted"><%= s.last_name %></div>
+        <% end %>
+      <% end %>
+
       <% desig_sid = designations_by_date.dig(date, "night").to_i %>
       <% desig_staff = staff_by_id[desig_sid] %>
       <% if desig_staff.present? && row_key_for(desig_staff) == row_key %>

--- a/app/views/shift_months/calendar_cells/_show.html.erb
+++ b/app/views/shift_months/calendar_cells/_show.html.erb
@@ -7,6 +7,7 @@
 %>
 
 <% month_begin = Date.new(shift_month.year, shift_month.month, 1) %>
+<% display_month_cell = in_month || date < month_begin %>
 <% ctx = shift_day_context(saved, date, carry_over_state: carry_over_state, shift_month: shift_month) %>
 <% late_time_options_by_id =
      shift_month.shift_month_time_options.late.index_by(&:id) %>
@@ -50,10 +51,10 @@
 <% else %>
   <div class="day-slots">
     <div class="slot slot-day">
-    <% if row_key == :care && in_month %>
+    <% if row_key == :care && display_month_cell %>
       <%# 介護だけ：固定順名簿で「勤務 or 休み」を表示 %>
       <% care_staffs =
-           staff_by_id.values
+          staff_by_id.values
                       .select { |s| s && row_key_for(s) == :care }
                       .sort_by do |s|
                         [
@@ -210,7 +211,7 @@
       <% end %>
 
       <%# 未割当(休み)表示：その月だけ %>
-      <% if in_month %>
+      <% if display_month_cell %>
         <% unassigned_staffs = (unassigned_display_staffs_by_date && unassigned_display_staffs_by_date[date]) || [] %>
         <% unassigned_staffs.each do |staff| %>
           <% next if staff.nil? || !staff.active? %>
@@ -224,7 +225,7 @@
       <% end %>
     <% end %>
 
-    <% if !(row_key == :care && in_month) %>
+    <% if !(row_key == :care && display_month_cell) %>
       <% early_rows.each do |row| %>
         <% sid = (row["staff_id"] || row[:staff_id]).to_i %>
         <% staff = staff_by_id[sid] %>

--- a/app/views/shift_months/settings.html.erb
+++ b/app/views/shift_months/settings.html.erb
@@ -70,5 +70,6 @@
               },
               designations_by_date: @designations_by_date,
               staff_by_id: @staff_by_id,
-              carry_over_state: @carry_over_state %>
+              carry_over_state: @carry_over_state,
+              previous_month_assignments_for_display: @previous_month_assignments_for_display %>
 <% end %>

--- a/app/views/shift_months/show.html.erb
+++ b/app/views/shift_months/show.html.erb
@@ -33,5 +33,7 @@
              unassigned_display_staffs_by_date: @unassigned_display_staffs_by_date,
              holiday_requests_by_date: @holiday_requests_by_date,
              designations_by_date: @designations_by_date,
-             carry_over_state: @carry_over_state %>
+             carry_over_state: @carry_over_state,
+             previous_month_assignments_for_display: @previous_month_assignments_for_display,
+             previous_month_unassigned_display_staffs_by_date: @previous_month_unassigned_display_staffs_by_date %>
 <% end %>


### PR DESCRIPTION
シフト作成時〜閲覧まで前の月の表示は保存されたシフトが視認できるように調整。