### PR TITLE
fix:細かい微調整

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -192,6 +192,17 @@
   background: #fafafa;
 }
 
+/* showページ：前月重なりセルを控えめに表示 */
+.shift-calendar-month td.day-cell.is-show-out {
+  background-color: #f1f3f5;
+}
+
+.shift-calendar-month td.day-cell.is-show-out .shift-line,
+.shift-calendar-month td.day-cell.is-show-out .small,
+.shift-calendar-month td.day-cell.is-show-out .holiday-in-slot {
+  opacity: 0.55;
+}
+
 /* 各日のセル内：日勤 / 夜勤 / 宿直 */
 .day-slots {
   display: grid;
@@ -289,16 +300,13 @@
 }
 
 /* 左サイドバー折りたたみ */
-body.sidebar-left-collapsed #sidebar-col {
+body.sidebar-left-collapsed #left-sidebar-col {
   display: none !important;
 }
 
-/* 左が消えた分、中央を広げる */
-@media (min-width: 768px) {
-  body.sidebar-left-collapsed #main-content {
-    flex: 0 0 calc(100% - 16.6666667%);
-    max-width: calc(100% - 16.6666667%);
-  }
+/* 左サイドバー非表示時も、中央はflexで自然に広げる */
+body.sidebar-left-collapsed #main-content {
+  min-width: 0;
 }
 
 /* =========================================

--- a/app/javascript/controllers/holiday_multi_select_controller.js
+++ b/app/javascript/controllers/holiday_multi_select_controller.js
@@ -18,7 +18,10 @@ export default class extends Controller {
           defaultDate: presetDates,
           minDate: this.inputTarget.dataset.minDate,
           maxDate: this.inputTarget.dataset.maxDate,
-          locale: Japanese,
+          locale: {
+            ...Japanese,
+            firstDayOfWeek: 1
+          },
           clickOpens: true,
           allowInput: false,
           onChange: this.handleChange.bind(this)

--- a/app/javascript/controllers/left_sidebar_controller.js
+++ b/app/javascript/controllers/left_sidebar_controller.js
@@ -4,11 +4,13 @@ export default class extends Controller {
   static values = { collapsed: Boolean }
 
   connect() {
+    this.collapsedValue = localStorage.getItem("sidebar-left-collapsed") === "true"
     this.apply()
   }
 
   toggle() {
     this.collapsedValue = !this.collapsedValue
+    localStorage.setItem("sidebar-left-collapsed", this.collapsedValue ? "true" : "false")
     this.apply()
   }
 

--- a/app/views/shift_months/_calendar.html.erb
+++ b/app/views/shift_months/_calendar.html.erb
@@ -89,7 +89,7 @@
               <% cell_unassigned_display_staffs_by_date =
                   in_month ? unassigned_display_staffs_by_date : previous_month_unassigned_display_staffs_by_date %>
 
-              <td class="day-cell <%= in_month ? "" : "is-out" %>">
+              <td class="day-cell <%= in_month ? "" : "is-out" %> <%= "is-show-out" if extra[:calendar_mode] == :show && !in_month %>">
                 <%= render cell_partial,
                           {
                             date: date,

--- a/app/views/shift_months/_frame.html.erb
+++ b/app/views/shift_months/_frame.html.erb
@@ -1,6 +1,8 @@
 <div class="container-fluid px-0">
   <div class="d-flex min-vh-100 flex-nowrap">
-    <div class="p-0 flex-shrink-0" style="width: 195px; background-color:#e6f0f0;">
+    <div id="left-sidebar-col"
+        class="p-0 flex-shrink-0"
+        style="width: 195px; background-color:#e6f0f0;">
       <%= render "layouts/sidebar" %>
     </div>
 

--- a/app/views/shift_months/show.html.erb
+++ b/app/views/shift_months/show.html.erb
@@ -27,6 +27,10 @@
              day_effective_by_date: @day_effective_by_date,
              required_by_date: @required_by_date,
              cell_partial: "shift_months/calendar_cells/show",
+             extra_locals: {
+               calendar_mode: :show
+             },
+             saved: @saved,
              saved: @saved,
              staff_by_id: @staff_by_id,
              alerts_by_date: @alerts_by_date,


### PR DESCRIPTION
以下を調整しました。
・シフト作成ページで左サイドバーをなくすボタンの不具合修正と、シフト生成後と手修正ページへの遷移時にも左サイドバーのなくした状態の設定が引き継がれるように調整
・シフト閲覧ページで前月のシフト表部分がグレーアウトするよう調整
・シフト作成ページの右サイドバーから休日設定をするためのカレンダーについて、月曜はじまりになるよう調整