### PR TITLE
fix:細かい調整

### DIFF
--- a/app/services/shift_drafts/random_generator.rb
+++ b/app/services/shift_drafts/random_generator.rb
@@ -375,14 +375,10 @@ module ShiftDrafts
       counted_staffs = lambda {
         day_staff_ids = day_rows.map { |row| row[:staff_id] }.compact.map(&:to_i)
 
-        if day_staff_ids.any?
-          scope
-            .where(id: day_staff_ids)
-            .includes(:occupation)
-            .reject { |staff| !staff.counts_toward_requirements? }
-        else
-          []
-        end
+        day_staff_ids
+          .map { |sid| @staff_by_id[sid.to_i] }
+          .compact
+          .select { |staff| staff.counts_toward_requirements? }
       }
 
       actual_skill_counts = lambda {

--- a/app/views/shift_months/_calendar.html.erb
+++ b/app/views/shift_months/_calendar.html.erb
@@ -89,7 +89,7 @@
               <% cell_unassigned_display_staffs_by_date =
                   in_month ? unassigned_display_staffs_by_date : previous_month_unassigned_display_staffs_by_date %>
 
-              <td class="day-cell <%= in_month ? "" : "is-out" %> <%= "is-show-out" if extra[:calendar_mode] == :show && !in_month %>">
+              <td class="day-cell <%= in_month ? "" : "is-out is-show-out" %>">
                 <%= render cell_partial,
                           {
                             date: date,

--- a/app/views/shift_months/_frame.html.erb
+++ b/app/views/shift_months/_frame.html.erb
@@ -7,9 +7,9 @@
     </div>
 
     <div id="main-content"
-         class="flex-grow-1 p-4 d-flex flex-column overflow-hidden"
-         style="height: 100vh; min-width: 0;"
-         data-controller="sync-scroll">
+        class="flex-grow-1 px-2 pt-1 pb-2 d-flex flex-column overflow-hidden"
+        style="height: 100vh; min-width: 0;"
+        data-controller="sync-scroll">
       <%= toolbar %>
 
       <div class="shift-calendar-area flex-grow-1 d-flex flex-column overflow-hidden" style="min-height: 0;">

--- a/app/views/shift_months/edit_draft.html.erb
+++ b/app/views/shift_months/edit_draft.html.erb
@@ -1,5 +1,5 @@
 <% toolbar = capture do %>
-  <div class="d-flex align-items-center gap-2 mb-3"
+  <div class="d-flex align-items-center gap-2 mb-1"
        data-controller="left-sidebar unsaved-guard"
        data-unsaved-guard-dirty-value="true">
     <button type="button"

--- a/app/views/shift_months/preview.html.erb
+++ b/app/views/shift_months/preview.html.erb
@@ -1,5 +1,5 @@
 <% toolbar = capture do %>
-  <div class="d-flex align-items-center gap-2 mb-3"
+  <div class="d-flex align-items-center gap-2 mb-1"
        data-controller="left-sidebar unsaved-guard"
        data-unsaved-guard-dirty-value="true"
        data-unsaved-guard-allow-urls-value="<%= edit_draft_shift_month_path(@shift_month) %>">

--- a/app/views/shift_months/settings.html.erb
+++ b/app/views/shift_months/settings.html.erb
@@ -25,7 +25,7 @@
     </div>
   <% end %>
 
-  <div class="d-flex align-items-center gap-2 mb-3" data-controller="left-sidebar">
+  <div class="d-flex align-items-center gap-2 mb-1" data-controller="left-sidebar">
     <button type="button"
             class="btn btn-sm btn-outline-secondary"
             data-action="left-sidebar#toggle">

--- a/app/views/shift_months/show.html.erb
+++ b/app/views/shift_months/show.html.erb
@@ -1,9 +1,17 @@
 <% toolbar = capture do %>
-  <div class="d-flex align-items-center gap-2 mb-3">
+  <div class="d-flex align-items-center gap-2 mb-1" data-controller="left-sidebar">
+    <button type="button"
+            class="btn btn-sm btn-outline-secondary"
+            data-action="left-sidebar#toggle">
+      <i class="bi bi-layout-sidebar-inset"></i>
+    </button>
+
     <%= link_to "戻る", new_shift_month_path, class:"btn btn-sm btn-light border" %>
+
     <%= button_to "手修正する", start_edit_from_confirmed_shift_month_path(@shift_month),
               method: :post,
               class: "btn btn-sm btn-primary" %>
+
     <%= link_to "Excel出力",
             export_excel_shift_month_path(@shift_month),
             class: "btn btn-sm btn-success" %>


### PR DESCRIPTION
以下の点を調整しました
・シフト作成に関連するページ全体に対し、シフト表が広く見えるようにボタン類の配置を調整
・シフト表の閲覧ページで、左サイドバーの開閉ボタンを追加
・シフト表の前月のシフト文字は全体的に薄字表示に変更