### PR TITLE
add:シフト生成後に充足アラートを実装

### DIFF
--- a/app/controllers/shift_months_controller.rb
+++ b/app/controllers/shift_months_controller.rb
@@ -981,6 +981,20 @@ end
       shift_month: @shift_month
     ).call
 
+    overstaffing_by_date = ShiftDrafts::OverstaffingBuilder.new(
+      dates: dates,
+      draft: @draft,
+      staff_by_id: @staff_by_id,
+      required_by_date: required_by_date,
+      enabled_by_date: {
+        day: enabled_maps[:day],
+        early: enabled_maps[:early],
+        late: enabled_maps[:late],
+        night: enabled_maps[:night]
+      },
+      shift_month: @shift_month
+    ).call
+
     holiday_requests_by_date =
       @shift_month.staff_holiday_requests
                   .includes(:staff)
@@ -1008,12 +1022,27 @@ end
         holiday_requests_by_date: holiday_requests_by_date,
         designations_by_date: designations_by_date
       )
+      over_msgs = Array(overstaffing_by_date[d])
 
-      alerts_html_by_date[d.iso8601] = render_to_string(
-        partial: "shift_months/calendar_cells/alert_body",
-        formats: [ :html ],
-        locals: { msgs: msgs }
-      )
+      html_parts = []
+
+      if msgs.any? || over_msgs.blank?
+        html_parts << render_to_string(
+          partial: "shift_months/calendar_cells/alert_body",
+          formats: [ :html ],
+          locals: { msgs: msgs }
+        )
+      end
+
+      if over_msgs.any?
+        html_parts << render_to_string(
+          partial: "shift_months/calendar_cells/overstaffing_body",
+          formats: [ :html ],
+          locals: { over_msgs: over_msgs }
+        )
+      end
+
+      alerts_html_by_date[d.iso8601] = html_parts.join
     end
 
     # night-slot(当日＋翌日)
@@ -1476,6 +1505,20 @@ end
 
     alert_dates = (@month_begin..@month_end).to_a
     @alerts_by_date = ShiftDrafts::AlertsBuilder.new(
+      dates: alert_dates,
+      draft: assignments_hash,
+      staff_by_id: @staff_by_id,
+      required_by_date: @required_by_date,
+      enabled_by_date: {
+        day: @day_enabled_by_date,
+        early: @early_enabled_by_date,
+        late: @late_enabled_by_date,
+        night: @night_enabled_by_date
+      },
+      shift_month: @shift_month
+    ).call
+
+    @overstaffing_by_date = ShiftDrafts::OverstaffingBuilder.new(
       dates: alert_dates,
       draft: assignments_hash,
       staff_by_id: @staff_by_id,

--- a/app/services/shift_drafts/overstaffing_builder.rb
+++ b/app/services/shift_drafts/overstaffing_builder.rb
@@ -1,0 +1,128 @@
+module ShiftDrafts
+  class OverstaffingBuilder
+    def initialize(dates:, draft:, staff_by_id:, required_by_date:, enabled_by_date:, shift_month:)
+      @dates = dates
+      @draft = draft
+      @staff_by_id = staff_by_id
+      @required_by_date = required_by_date
+      @enabled_by_date = enabled_by_date
+      @shift_month = shift_month
+    end
+
+    def call
+      overstaffing = {}
+
+      @dates.each do |date|
+        dkey = date.iso8601
+        kinds_hash = @draft[dkey] || {}
+
+        list = []
+        day_msg = day_overstaffing_message(date, kinds_hash)
+        list << day_msg if day_msg.present?
+
+        early_over = early_overstaffing_count(date, kinds_hash)
+        late_over = late_overstaffing_count(date, kinds_hash)
+        night_over = night_overstaffing_count(date, kinds_hash)
+
+        list << "早+#{early_over}" if early_over > 0
+        list << "遅+#{late_over}" if late_over > 0
+        list << "夜+#{night_over}" if night_over > 0
+
+        overstaffing[date] = list if list.any?
+      end
+
+      overstaffing
+    end
+
+    private
+
+    def day_overstaffing_message(date, kinds_hash)
+      return nil unless enabled?(:day, date)
+
+      req = @required_by_date[date] || { nurse: 0, care: 0 }
+      req_nurse = req[:nurse].to_i
+      req_care = req[:care].to_i
+
+      actual = day_actual_counts(kinds_hash)
+
+      over_nurse = [ actual[:nurse] - req_nurse, 0 ].max
+      over_care = [ actual[:care] - req_care, 0 ].max
+
+      parts = []
+      parts << "看＋#{over_nurse}" if over_nurse > 0
+      parts << "介＋#{over_care}" if over_care > 0
+
+      return nil if parts.blank?
+
+      "日勤：#{parts.join(' ')}"
+    end
+
+    def early_overstaffing_count(date, kinds_hash)
+      return 0 unless enabled?(:early, date)
+
+      actual = kind_count(kinds_hash, "early")
+      [ actual - 1, 0 ].max
+    end
+
+    def late_overstaffing_count(date, kinds_hash)
+      return 0 unless enabled?(:late, date)
+
+      required = @shift_month.late_slots_for(date).to_i
+      required = 1 if required <= 0
+      required = 2 if required >= 2
+
+      actual = kind_count(kinds_hash, "late")
+      [ actual - required, 0 ].max
+    end
+
+    def night_overstaffing_count(date, kinds_hash)
+      return 0 unless enabled?(:night, date)
+
+      actual = kind_count(kinds_hash, "night")
+      [ actual - 1, 0 ].max
+    end
+
+    def enabled?(kind_sym, date)
+      map = @enabled_by_date[kind_sym]
+      return false if map.nil?
+
+      map[date] == true
+    end
+
+    def kind_count(kinds_hash, kind)
+      rows = kinds_hash[kind] || kinds_hash[kind.to_sym]
+      Array(rows).size
+    end
+
+    def day_actual_counts(kinds_hash)
+      nurse = 0
+      care = 0
+
+      rows = kinds_hash["day"] || kinds_hash[:day]
+
+      Array(rows).each do |row|
+        sid = extract_staff_id(row)
+        next if sid.nil?
+
+        staff = @staff_by_id[sid.to_i]
+        next if staff.nil?
+        next unless staff.counts_toward_requirements?
+
+        occ_name = staff.occupation&.name.to_s
+
+        nurse += 1 if occ_name.include?("看護")
+        care += 1 if occ_name.include?("介護")
+      end
+
+      { nurse: nurse, care: care }
+    end
+
+    def extract_staff_id(row)
+      return nil if row.nil?
+      return row.to_i unless row.is_a?(Hash)
+
+      v = row["staff_id"] || row[:staff_id]
+      v.present? ? v.to_i : nil
+    end
+  end
+end

--- a/app/views/shift_months/_calendar.html.erb
+++ b/app/views/shift_months/_calendar.html.erb
@@ -2,7 +2,7 @@
   weeks:, shift_month:, occupation_order:, holiday_by_date:,
   day_enabled_by_date:, night_enabled_by_date:, day_effective_by_date:, required_by_date:,
   early_enabled_by_date:, late_enabled_by_date:, required_skill_by_date:,
-  staff_by_id:, draft:, saved:, alerts_by_date:, designations_by_date:, holiday_requests_by_date:,
+  staff_by_id:, draft:, saved:, alerts_by_date:, overstaffing_by_date:, designations_by_date:, holiday_requests_by_date:,
   cell_partial:, unassigned_display_staffs_by_date:, carry_over_state:
 %>
 <%# extra_locals: セル側に追加で渡したいlocals（Hash） %>
@@ -15,6 +15,7 @@
 <% draft                            = local_assigns.fetch(:draft, nil) %>
 <% saved                            = local_assigns.fetch(:saved, nil) %>
 <% alerts_by_date                   = local_assigns.fetch(:alerts_by_date, nil) %>
+<% overstaffing_by_date             = local_assigns.fetch(:overstaffing_by_date, {}) || {} %>
 <% designations_by_date             = local_assigns.fetch(:designations_by_date, {}) || {} %>
 <% holiday_requests_by_date         = local_assigns.fetch(:holiday_requests_by_date, nil) %>
 <% unassigned_display_staffs_by_date = local_assigns.fetch(:unassigned_display_staffs_by_date, nil) %>
@@ -106,6 +107,7 @@
                             draft: cell_draft,
                             saved: cell_saved,
                             alerts_by_date: alerts_by_date,
+                            overstaffing_by_date: overstaffing_by_date,
                             designations_by_date: designations_by_date,
                             holiday_requests_by_date: holiday_requests_by_date,
                             unassigned_display_staffs_by_date: cell_unassigned_display_staffs_by_date,

--- a/app/views/shift_months/calendar_cells/_edit_draft.html.erb
+++ b/app/views/shift_months/calendar_cells/_edit_draft.html.erb
@@ -1,7 +1,7 @@
 <%# locals:
   date:, in_month:, occupation:, row_key:, shift_month:,
   day_enabled_by_date:, early_enabled_by_date:, late_enabled_by_date:,
-  required_by_date:, required_skill_by_date:, alerts_by_date:,
+  required_by_date:, required_skill_by_date:, alerts_by_date:, overstaffing_by_date:,
   draft:, staff_by_id:, unassigned_display_staffs_by_date:,
   holiday_requests_by_date:, designations_by_date:, carry_over_state:
 %>
@@ -33,8 +33,27 @@
               holiday_requests_by_date: holiday_requests_by_date,
               designations_by_date: designations_by_date
             ) %>
+  <% over_msgs = Array(local_assigns[:overstaffing_by_date]&.[](date)) %>
+
   <div id="alert-cell-<%= date.iso8601 %>">
-    <%= render "shift_months/calendar_cells/alert_body", msgs: msgs %>
+    <% if msgs.any? %>
+      <%= render "shift_months/calendar_cells/alert_body", msgs: msgs %>
+    <% elsif over_msgs.blank? %>
+      <%= render "shift_months/calendar_cells/alert_body", msgs: msgs %>
+    <% end %>
+
+    <% if over_msgs.any? %>
+      <div class="d-flex flex-wrap gap-1 small mt-1">
+        <% over_msgs.each do |msg| %>
+          <span
+            class="badge rounded-pill bg-info-subtle text-info-emphasis border border-info-subtle"
+            style="--bs-badge-padding-x: 0.35em; --bs-badge-padding-y: 0.12em; line-height: 1;"
+          >
+            <%= msg %>
+          </span>
+        <% end %>
+      </div>
+    <% end %>
   </div>
 <% else %>
   <div class="day-slots">

--- a/app/views/shift_months/calendar_cells/_overstaffing_body.html.erb
+++ b/app/views/shift_months/calendar_cells/_overstaffing_body.html.erb
@@ -1,0 +1,14 @@
+<% over_msgs = Array(over_msgs) %>
+
+<% if over_msgs.any? %>
+  <div class="d-flex flex-wrap gap-1 small mt-1">
+    <% over_msgs.each do |msg| %>
+      <span
+        class="badge rounded-pill bg-info-subtle text-info-emphasis border border-info-subtle"
+        style="--bs-badge-padding-x: 0.35em; --bs-badge-padding-y: 0.12em; line-height: 1;"
+        >
+        <%= msg %>
+      </span>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/shift_months/calendar_cells/_preview.html.erb
+++ b/app/views/shift_months/calendar_cells/_preview.html.erb
@@ -1,7 +1,7 @@
 <%# locals:
   date:, in_month:, occupation:, row_key:, shift_month:,
   day_enabled_by_date:, early_enabled_by_date:, late_enabled_by_date:,
-  required_by_date:, required_skill_by_date:, alerts_by_date:,
+  required_by_date:, required_skill_by_date:, alerts_by_date:, overstaffing_by_date:,
   draft:, staff_by_id:, unassigned_display_staffs_by_date:,
   holiday_requests_by_date:, designations_by_date:, carry_over_state:
 %>
@@ -37,7 +37,26 @@
               designations_by_date: designations_by_date
             ) %>
 
-  <%= render "shift_months/calendar_cells/alert_body", msgs: msgs %>
+  <% over_msgs = Array(local_assigns[:overstaffing_by_date]&.[](date)) %>
+
+  <% if msgs.any? %>
+    <%= render "shift_months/calendar_cells/alert_body", msgs: msgs %>
+  <% elsif over_msgs.blank? %>
+    <%= render "shift_months/calendar_cells/alert_body", msgs: msgs %>
+  <% end %>
+
+  <% if over_msgs.any? %>
+    <div class="d-flex flex-wrap gap-1 small mt-1">
+      <% over_msgs.each do |msg| %>
+        <span
+          class="badge rounded-pill bg-info-subtle text-info-emphasis border border-info-subtle"
+          style="--bs-badge-padding-x: 0.35em; --bs-badge-padding-y: 0.12em; line-height: 1;"
+        >
+          <%= msg %>
+        </span>
+      <% end %>
+    </div>
+  <% end %>
 <% else %>
   <div class="day-slots">
     <div class="slot slot-day">

--- a/app/views/shift_months/calendar_cells/_show.html.erb
+++ b/app/views/shift_months/calendar_cells/_show.html.erb
@@ -2,7 +2,7 @@
   date:, in_month:, occupation:, row_key:, shift_month:,
   day_enabled_by_date:, early_enabled_by_date:, late_enabled_by_date:,
   required_by_date:, required_skill_by_date:, saved:, staff_by_id:,
-  alerts_by_date:, unassigned_display_staffs_by_date:, holiday_requests_by_date:,
+  alerts_by_date:, overstaffing_by_date:, unassigned_display_staffs_by_date:, holiday_requests_by_date:,
   designations_by_date:, carry_over_state:
 %>
 
@@ -38,13 +38,30 @@
               designations_by_date: designations_by_date
             ) %>
 
-  <% if msgs.any? %>
-    <div class="d-flex flex-wrap gap-1 small">
-      <% msgs.each do |msg| %>
-        <% badge_class = alert_badge_class(msg) %>
-        <span class="badge rounded-pill <%= badge_class %>"><%= msg %></span>
-      <% end %>
-    </div>
+  <% over_msgs = Array(local_assigns[:overstaffing_by_date]&.[](date)) %>
+
+  <% if msgs.any? || over_msgs.any? %>
+    <% if msgs.any? %>
+      <div class="d-flex flex-wrap gap-1 small">
+        <% msgs.each do |msg| %>
+          <% badge_class = alert_badge_class(msg) %>
+          <span class="badge rounded-pill <%= badge_class %>"><%= msg %></span>
+        <% end %>
+      </div>
+    <% end %>
+
+    <% if over_msgs.any? %>
+      <div class="d-flex flex-wrap gap-1 small mt-1">
+        <% over_msgs.each do |msg| %>
+          <span
+            class="badge rounded-pill bg-info-subtle text-info-emphasis border border-info-subtle"
+            style="--bs-badge-padding-x: 0.35em; --bs-badge-padding-y: 0.12em; line-height: 1;"
+          >
+            <%= msg %>
+          </span>
+        <% end %>
+      </div>
+    <% end %>
   <% else %>
     <div class="text-muted small">-</div>
   <% end %>

--- a/app/views/shift_months/edit_draft.html.erb
+++ b/app/views/shift_months/edit_draft.html.erb
@@ -41,6 +41,7 @@
             staff_by_id: @staff_by_id,
             designations_by_date: @designations_by_date,
             alerts_by_date: @alerts_by_date,
+            overstaffing_by_date: @overstaffing_by_date,
             holiday_requests_by_date: @holiday_requests_by_date,
             unassigned_display_staffs_by_date: @unassigned_display_staffs_by_date,
             carry_over_state: @carry_over_state %>

--- a/app/views/shift_months/preview.html.erb
+++ b/app/views/shift_months/preview.html.erb
@@ -46,6 +46,7 @@
              staff_by_id: @staff_by_id,
              designations_by_date: @designations_by_date,
              alerts_by_date: @alerts_by_date,
+             overstaffing_by_date: @overstaffing_by_date,
              holiday_requests_by_date: @holiday_requests_by_date,
              unassigned_display_staffs_by_date: @unassigned_display_staffs_by_date,
              carry_over_state: @carry_over_state %>

--- a/app/views/shift_months/show.html.erb
+++ b/app/views/shift_months/show.html.erb
@@ -42,6 +42,7 @@
              saved: @saved,
              staff_by_id: @staff_by_id,
              alerts_by_date: @alerts_by_date,
+             overstaffing_by_date: @overstaffing_by_date,
              unassigned_display_staffs_by_date: @unassigned_display_staffs_by_date,
              holiday_requests_by_date: @holiday_requests_by_date,
              designations_by_date: @designations_by_date,


### PR DESCRIPTION
シフト生成後に、不足アラートと同様に、人員配置より人数が多い場合には充足アラートでお知らせがでるように実装